### PR TITLE
Implement intro animation without committing binary images

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,34 +4,82 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Dangerous Spaceballs</title>
-    <script src="https://cdn.jsdelivr.net/npm/phaser@3/dist/phaser.min.js"></script>
     <style>
-        body {
+        body, html {
             margin: 0;
             padding: 0;
+            width: 100%;
+            height: 100%;
+        }
+        #start-screen {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            background: url('images/promo.webp') center center / cover no-repeat;
+        }
+        #promo-animation {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            display: none;
+            justify-content: center;
+            align-items: center;
+            background: #000;
+        }
+        #promo-animation img {
+            max-width: 100%;
+            max-height: 100%;
         }
         #game {
             width: 100vw;
             height: 100vh;
+            display: none;
         }
     </style>
 </head>
 <body>
+    <div id="start-screen">
+        <button id="start-button">Start</button>
+    </div>
+    <div id="promo-animation">
+        <img src="images/promo_animated.webp" alt="Promo Animation">
+    </div>
     <div id="game"></div>
+    <script src="https://cdn.jsdelivr.net/npm/phaser@3/dist/phaser.min.js"></script>
     <script>
-        const config = {
-            type: Phaser.AUTO,
-            width: 800,
-            height: 600,
-            scene: {
-                preload: function() {},
-                create: function() {
-                    this.add.text(100, 100, 'Hello Phaser!', { font: '40px Arial', fill: '#ffffff' });
-                },
-                update: function() {}
-            }
-        };
-        const game = new Phaser.Game(config);
+        function startGame() {
+            const config = {
+                type: Phaser.AUTO,
+                width: 800,
+                height: 600,
+                scene: {
+                    preload: function() {},
+                    create: function() {
+                        this.add.text(100, 100, 'Hello Phaser!', { font: '40px Arial', fill: '#ffffff' });
+                    },
+                    update: function() {}
+                }
+            };
+            new Phaser.Game(config);
+        }
+
+        document.getElementById('start-button').addEventListener('click', function() {
+            document.getElementById('start-screen').style.display = 'none';
+            const promo = document.getElementById('promo-animation');
+            promo.style.display = 'flex';
+            setTimeout(function() {
+                promo.style.display = 'none';
+                document.getElementById('game').style.display = 'block';
+                startGame();
+            }, 3000);
+        });
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- revert binary image additions
- add start screen and animated promo sequence in `index.html`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6852df69a804832bb4e5f7155f5237b6