### PR TITLE
Add BDD tests for boost and shooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@ A simple js game to test out phaser.
 
 - Centered playfield framed by glowing edges.
 - Ship & reticle interaction: the triangular ship rotates toward the mouse and a reticle follows your pointer.
-- Thruster boost triggered by right-click, complete with flame effect and fuel meter.
-- Laser firing with left-click; hold to shoot repeatedly until ammo runs out.
 - Orb spawning & growth: red and blue orbs appear and grow before becoming active.
 - Orb drift & bounce once grown, making them move and ricochet off screen edges.
 - Collision consequences: red orbs add score and streak, blue orbs subtract score, and crashing into any orb ends the game.

--- a/features/laser_firing.feature
+++ b/features/laser_firing.feature
@@ -1,0 +1,9 @@
+Feature: Laser firing
+  Scenario: Holding left mouse button fires bullets and drains ammo
+    Given I open the game page
+    When I click the start button
+    Then the game should appear after a short delay
+    When I hold the left mouse button for 300 ms
+    Then bullets should be fired
+    And the ammo should decrease
+    When I release the left mouse button

--- a/features/thruster_boost.feature
+++ b/features/thruster_boost.feature
@@ -1,0 +1,9 @@
+Feature: Thruster Boost
+  Scenario: Activating the thruster consumes fuel and shows flame
+    Given I open the game page
+    When I click the start button
+    Then the game should appear after a short delay
+    When I hold the right mouse button for 300 ms
+    Then the flame should be visible
+    And the fuel should decrease
+    When I release the right mouse button


### PR DESCRIPTION
## Summary
- remove boost and firing features from README
- add new feature tests for thruster boost and laser firing
- improve start delay for game load
- enhance step definitions for interaction

## Testing
- `npm run check`
- `npx cucumber-js --format progress`

------
https://chatgpt.com/codex/tasks/task_e_68531f1420e4832ba539628baabd9c5d