### PR TITLE
Add streak text and scoring

### DIFF
--- a/features/step_definitions/steps.js
+++ b/features/step_definitions/steps.js
@@ -104,3 +104,32 @@ Then('the ammo should decrease', async () => {
 AfterAll(async () => {
   await browser?.close();
 });
+
+When('I simulate hitting {int} red orbs', async count => {
+  await page.waitForFunction(() => window.gameScene && window.gameScene.handleOrbHit);
+  await page.evaluate(c => {
+    for (let i = 0; i < c; i++) {
+      window.gameScene.handleOrbHit(0xff0000, 400, 300, window.gameScene.time.now);
+    }
+  }, count);
+});
+
+Then('the streak should be {int}', async expected => {
+  const val = await page.evaluate(() => window.gameScene.streak);
+  if (val !== expected) {
+    throw new Error(`Expected streak ${expected} but got ${val}`);
+  }
+});
+
+Then('the score should be {int}', async expected => {
+  const val = await page.evaluate(() => window.gameScene.score);
+  if (val !== expected) {
+    throw new Error(`Expected score ${expected} but got ${val}`);
+  }
+});
+
+Then('the streak text {string} should appear', async text => {
+  await page.waitForFunction(t => {
+    return window.gameScene.floatingTexts.some(ft => ft.sprite.text === t);
+  }, text);
+});

--- a/features/streak_feedback.feature
+++ b/features/streak_feedback.feature
@@ -1,0 +1,9 @@
+Feature: Streak feedback
+  Scenario: Score scaling and streak announcement
+    Given I open the game page
+    When I click the start button
+    Then the game should appear after a short delay
+    When I simulate hitting 5 red orbs
+    Then the streak should be 5
+    And the score should be 150
+    And the streak text "Streak 5!" should appear

--- a/index.html
+++ b/index.html
@@ -168,6 +168,24 @@
                 this.flame.setOrigin(0.5, 0.5);
                 this.flame.visible = false;
 
+                // Handle orb collisions and scoring
+                this.handleOrbHit = (color, x, y, time) => {
+                    if (color === 0xff0000) {
+                        this.streak += 1;
+                        this.score += 10 * this.streak;
+                        if (this.streak % 5 === 0) {
+                            const txt = this.add.text(x, y, `Streak ${this.streak}!`, { font: '20px Arial', color: '#ff00ff' });
+                            txt.setOrigin(0.5);
+                            this.floatingTexts.push({ sprite: txt, spawnTime: time });
+                        }
+                    } else {
+                        this.score -= 5;
+                        this.streak = 0;
+                    }
+                    document.getElementById('score').textContent = this.score;
+                    document.getElementById('streak').textContent = this.streak;
+                };
+
                 document.getElementById('ammo-count').textContent = this.ammo;
                 this.score = 0;
                 this.streak = 0;
@@ -279,15 +297,7 @@
                         const dx = b.sprite.x - o.sprite.x;
                         const dy = b.sprite.y - o.sprite.y;
                         if (dx * dx + dy * dy <= r * r) {
-                            if (o.sprite.fillColor === 0xff0000) {
-                                this.score += 10;
-                                this.streak += 1;
-                            } else {
-                                this.score -= 5;
-                                this.streak = 0;
-                            }
-                            document.getElementById('score').textContent = this.score;
-                            document.getElementById('streak').textContent = this.streak;
+                            this.handleOrbHit(o.sprite.fillColor, o.sprite.x, o.sprite.y, time);
                             o.sprite.destroy();
                             this.orbs.splice(j, 1);
                             b.sprite.destroy();


### PR DESCRIPTION
## Summary
- scale red orb scoring based on streak counter
- show flashy text on every streak multiple of five
- support simulating orb hits and verifying streak text in tests
- add BDD test covering streak bonus

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68532972dd70832b8c53ae41a62f81f8