### PR TITLE
Add level progression feature

### DIFF
--- a/features/level_progression.feature
+++ b/features/level_progression.feature
@@ -1,0 +1,7 @@
+Feature: Level progression
+  Scenario: Difficulty increases over time
+    Given I open the game page
+    When I click the start button
+    Then the game should appear after a short delay
+    When I wait for 15500 ms
+    Then the level should be 2

--- a/features/step_definitions/steps.js
+++ b/features/step_definitions/steps.js
@@ -133,3 +133,23 @@ Then('the streak text {string} should appear', async text => {
     return window.gameScene.floatingTexts.some(ft => ft.sprite.text === t);
   }, text);
 });
+
+When('I wait for {int} ms', async ms => {
+  await page.waitForTimeout(ms);
+});
+
+Then('the level banner should show {string}', async text => {
+  await page.waitForFunction(t => {
+    const el = document.getElementById('level-banner');
+    if (!el) return false;
+    const style = getComputedStyle(el);
+    return el.textContent === t && parseFloat(style.opacity) > 0;
+  }, text);
+});
+
+Then('the level should be {int}', async expected => {
+  const val = await page.evaluate(() => window.gameScene.level);
+  if (val !== expected) {
+    throw new Error(`Expected level ${expected} but got ${val}`);
+  }
+});

--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
     <div id="fuel-container"><div id="fuel-bar"></div></div>
     <div id="ammo-container">Ammo: <span id="ammo-count">0</span></div>
     <div id="score-container">Score: <span id="score">0</span> | Streak: <span id="streak">0</span> | Time: <span id="time-remaining">60</span></div>
+    <div id="level-banner"></div>
     <script src="lib/phaser.min.js"></script>
     <script src="main.js"></script>
 </body>

--- a/main.js
+++ b/main.js
@@ -63,6 +63,37 @@
                 this.nextOrbSpawn = 0;
                 this.orbSpawnRate = 3000; // milliseconds
                 this.orbGrowthDuration = 500;
+                this.orbSpeedMultiplier = 1;
+
+                this.level = 1;
+                this.nextLevelTime = this.time.now + 15000;
+                this.levelBanner = document.getElementById('level-banner');
+                this.showLevelBanner = level => {
+                    this.levelBanner.textContent = `Level ${level}`;
+                    this.levelBanner.style.opacity = '1';
+                    setTimeout(() => {
+                        this.levelBanner.style.opacity = '0';
+                    }, 2000);
+                };
+                this.showLevelBanner(1);
+
+                this.spawnOrb = (color, t) => {
+                    const x = Phaser.Math.Between(0, this.scale.width);
+                    const y = Phaser.Math.Between(0, this.scale.height);
+                    const radius = 10;
+                    const orb = this.add.circle(x, y, radius, color);
+                    orb.setScale(0);
+                    const angle = Phaser.Math.FloatBetween(0, Math.PI * 2);
+                    const speed = 50 * this.orbSpeedMultiplier;
+                    this.orbs.push({
+                        sprite: orb,
+                        radius: radius,
+                        vx: Math.cos(angle) * speed,
+                        vy: Math.sin(angle) * speed,
+                        spawnTime: t,
+                        growing: true
+                    });
+                };
 
                 // Flame effect for boosting
                 this.flame = this.add.triangle(0, 0, 0, 0, 5, 15, -5, 15, 0xffa500);
@@ -225,23 +256,21 @@
                     this.nextPowerUpSpawn = time + this.powerUpSpawnRate;
                 }
 
+                if (time > this.nextLevelTime) {
+                    this.level += 1;
+                    this.nextLevelTime += 15000;
+                    this.orbSpeedMultiplier *= 1.2;
+                    for (const o of this.orbs) {
+                        o.vx *= 1.2;
+                        o.vy *= 1.2;
+                    }
+                    this.spawnOrb(0x0000ff, time);
+                    this.showLevelBanner(this.level);
+                }
+
                 if (time > this.nextOrbSpawn) {
-                    const x = Phaser.Math.Between(0, this.scale.width);
-                    const y = Phaser.Math.Between(0, this.scale.height);
                     const color = Math.random() < 0.5 ? 0xff0000 : 0x0000ff;
-                    const radius = 10;
-                    const orb = this.add.circle(x, y, radius, color);
-                    orb.setScale(0);
-                    const angle = Phaser.Math.FloatBetween(0, Math.PI * 2);
-                    const speed = 50;
-                    this.orbs.push({
-                        sprite: orb,
-                        radius: radius,
-                        vx: Math.cos(angle) * speed,
-                        vy: Math.sin(angle) * speed,
-                        spawnTime: time,
-                        growing: true
-                    });
+                    this.spawnOrb(color, time);
                     this.nextOrbSpawn = time + this.orbSpawnRate;
                 }
 

--- a/style.css
+++ b/style.css
@@ -75,3 +75,16 @@ body, html {
 body.urgent {
     animation: pulseRed 1s infinite;
 }
+
+#level-banner {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    font-size: 48px;
+    font-family: Arial, sans-serif;
+    color: #fff;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 1s;
+}


### PR DESCRIPTION
## Summary
- add `level-banner` element and styling
- introduce level progression logic that speeds up orbs every 15 seconds
- show a fading banner announcing each new level
- add scenario covering level increase
- extend step definitions with generic wait and level checks

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68532ee69178832ba7a42c224c33ee53