### PR TITLE
Add configurable level duration

### DIFF
--- a/features/level_progression.feature
+++ b/features/level_progression.feature
@@ -1,7 +1,8 @@
 Feature: Level progression
   Scenario: Difficulty increases over time
     Given I open the game page
+    And the level progression interval is 1000 ms
     When I click the start button
     Then the game should appear after a short delay
-    When I wait for 15500 ms
-    Then the level should be 2
+    When I wait for 600 ms
+    Then the level should be 5

--- a/features/step_definitions/steps.js
+++ b/features/step_definitions/steps.js
@@ -6,6 +6,10 @@ setDefaultTimeout(60 * 1000);
 
 let browser, page;
 
+Given('the level progression interval is {int} ms', async ms => {
+  await page.evaluate(m => { window.levelDuration = m; }, ms);
+});
+
 Given('I open the game page', async () => {
   browser = await chromium.launch({
     args: ['--no-sandbox', '--ignore-certificate-errors', '--allow-file-access-from-files']

--- a/index.html
+++ b/index.html
@@ -19,6 +19,13 @@
     <div id="score-container">Score: <span id="score">0</span> | Streak: <span id="streak">0</span> | Time: <span id="time-remaining">60</span></div>
     <div id="level-banner"></div>
     <script src="lib/phaser.min.js"></script>
+    <script>
+        const params = new URLSearchParams(window.location.search);
+        const ld = parseInt(params.get('levelDuration'));
+        if (!isNaN(ld)) {
+            window.levelDuration = ld;
+        }
+    </script>
     <script src="main.js"></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -10,7 +10,7 @@
             osc.stop(ctx.currentTime + 0.1);
         }
 
-        function startGame() {
+        function startGame(levelDurationMs = 15000) {
             const config = {
                 type: Phaser.AUTO,
                 parent: 'game',
@@ -66,7 +66,8 @@
                 this.orbSpeedMultiplier = 1;
 
                 this.level = 1;
-                this.nextLevelTime = this.time.now + 15000;
+                this.levelDuration = levelDurationMs;
+                this.nextLevelTime = this.time.now + this.levelDuration;
                 this.levelBanner = document.getElementById('level-banner');
                 this.showLevelBanner = level => {
                     this.levelBanner.textContent = `Level ${level}`;
@@ -258,7 +259,7 @@
 
                 if (time > this.nextLevelTime) {
                     this.level += 1;
-                    this.nextLevelTime += 15000;
+                    this.nextLevelTime += this.levelDuration;
                     this.orbSpeedMultiplier *= 1.2;
                     for (const o of this.orbs) {
                         o.vx *= 1.2;
@@ -375,6 +376,6 @@
             setTimeout(function() {
                 promo.style.display = 'none';
                 document.getElementById('game').style.display = 'block';
-                startGame();
+                startGame(window.levelDuration);
             }, 3000);
         });


### PR DESCRIPTION
## Summary
- make `startGame` accept a `levelDurationMs` parameter
- use `window.levelDuration` or query parameter to set level duration
- expose query parameter logic in index.html
- add step for setting level progression interval in BDD tests
- adjust level progression feature to use the new step and shorter wait

## Testing
- `npm run check`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853376017f8832baf3601f4c98690ae