### PR TITLE
Add immersive audio system

### DIFF
--- a/features/music.feature
+++ b/features/music.feature
@@ -1,0 +1,7 @@
+Feature: Background music
+  Scenario: Music transitions from menu to gameplay
+    Given I open the game page
+    Then menu music should be playing
+    When I click the start button
+    Then the game should appear after a short delay
+    Then gameplay music should be playing

--- a/features/step_definitions/steps.js
+++ b/features/step_definitions/steps.js
@@ -153,3 +153,19 @@ Then('the level should be {int}', async expected => {
     throw new Error(`Expected level ${expected} but got ${val}`);
   }
 });
+
+Then('menu music should be playing', async () => {
+  await page.waitForFunction(() => window.audioElements?.menuMusic);
+  const exists = await page.evaluate(() => !!window.audioElements.menuMusic);
+  if (!exists) {
+    throw new Error('Menu music not initialized');
+  }
+});
+
+Then('gameplay music should be playing', async () => {
+  await page.waitForFunction(() => window.currentGameplayMusic);
+  const exists = await page.evaluate(() => !!window.currentGameplayMusic);
+  if (!exists) {
+    throw new Error('Gameplay music not initialized');
+  }
+});


### PR DESCRIPTION
## Summary
- implement audio objects for background music and sound effects
- hook up playback triggers for shooting, boosting, pickups and game over
- transition from menu music to gameplay tracks after intro
- add BDD test verifying music setup

## Testing
- `npm run check`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853b601b4b8832b959395f691513d51