### PR TITLE
Fix BDD workflow artifact action version

### DIFF
--- a/.github/workflows/bdd.yml
+++ b/.github/workflows/bdd.yml
@@ -32,7 +32,7 @@ jobs:
           node scripts/generate-duration-report.js
       - name: Upload report
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bdd-duration-report
           path: bdd-duration-report.html


### PR DESCRIPTION
## Summary
- update BDD workflow to use `actions/upload-artifact@v4`

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6853c766a408832b81e2376556c4ab6d