### PR TITLE
Add After hook to close browser per scenario

### DIFF
--- a/features/step_definitions/steps.js
+++ b/features/step_definitions/steps.js
@@ -1,4 +1,4 @@
-const { Given, When, Then, AfterAll, setDefaultTimeout } = require('@cucumber/cucumber');
+const { Given, When, Then, After, AfterAll, setDefaultTimeout } = require('@cucumber/cucumber');
 const { chromium } = require('playwright');
 const path = require('path');
 
@@ -103,6 +103,10 @@ Then('the ammo should decrease', async () => {
   if (ammo >= 50) {
     throw new Error('Ammo did not decrease');
   }
+});
+
+After(async () => {
+  await browser?.close();
 });
 
 AfterAll(async () => {


### PR DESCRIPTION
## Summary
- close Playwright browser after each scenario
- keep AfterAll as safety net for stray browsers

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6853d48dec78832b9d88946a57748605