### PR TITLE
Enable parallel BDD runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ npx playwright install
 - **Unit tests**: `npm run check`
 - **BDD tests**: `npm test`
 
+BDD tests run in parallel by default. Set the environment variable
+`CUCUMBER_PARALLEL` to control how many worker processes are used:
+
+```bash
+# run with four workers
+CUCUMBER_PARALLEL=4 npm test
+```
+
 
 ## BDD duration report
 

--- a/features/step_definitions/steps.js
+++ b/features/step_definitions/steps.js
@@ -1,4 +1,4 @@
-const { Given, When, Then, AfterAll, setDefaultTimeout } = require('@cucumber/cucumber');
+const { Given, When, Then, BeforeAll, Before, After, AfterAll, setDefaultTimeout } = require('@cucumber/cucumber');
 const { chromium } = require('playwright');
 const path = require('path');
 
@@ -6,16 +6,26 @@ setDefaultTimeout(60 * 1000);
 
 let browser, page;
 
+BeforeAll(async () => {
+  browser = await chromium.launch({
+    args: ['--no-sandbox', '--ignore-certificate-errors', '--allow-file-access-from-files']
+  });
+});
+
+Before(async () => {
+  const ctx = await browser.newContext();
+  page = await ctx.newPage();
+});
+
+After(async () => {
+  await page?.context()?.close();
+});
+
 Given('the level progression interval is {int} ms', async ms => {
   await page.evaluate(m => { window.levelDuration = m; }, ms);
 });
 
 Given('I open the game page', async () => {
-  browser = await chromium.launch({
-    args: ['--no-sandbox', '--ignore-certificate-errors', '--allow-file-access-from-files']
-  });
-  const ctx = await browser.newContext();
-  page = await ctx.newPage();
   const filePath = path.resolve(__dirname, '../../index.html');
   await page.goto('file://' + filePath);
 });

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "npm run check && cucumber-js",
+    "test": "npm run check && cucumber-js --parallel ${CUCUMBER_PARALLEL:-2}",
     "check": "node test/check_orb_radius.js"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- run cucumber-js in parallel via `CUCUMBER_PARALLEL`
- use Playwright browser contexts per scenario
- document parallel configuration

## Testing
- `npm run check`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853cf7b9708832b8dc571947be630f8