### PR TITLE
Fix BDD failures by not closing browser per scenario

### DIFF
--- a/features/step_definitions/steps.js
+++ b/features/step_definitions/steps.js
@@ -115,10 +115,6 @@ Then('the ammo should decrease', async () => {
   }
 });
 
-After(async () => {
-  await browser?.close();
-});
-
 AfterAll(async () => {
   await browser?.close();
 });


### PR DESCRIPTION
## Summary
- remove `After` hook closing the browser after each scenario
- keep single `AfterAll` hook to close browser once after all scenarios

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6853db811678832ba4dc0fdb714c8234