### PR TITLE
Improve game wait logic

### DIFF
--- a/features/step_definitions/steps.js
+++ b/features/step_definitions/steps.js
@@ -29,7 +29,7 @@ Then('the promo animation should be shown', async () => {
 });
 
 Then('the game should appear after a short delay', async () => {
-  await page.waitForTimeout(4000);
+  await page.waitForSelector('#game', { state: 'visible' });
   const display = await page.$eval('#game', el => getComputedStyle(el).display);
   if (display === 'none') {
     throw new Error('Game did not appear');


### PR DESCRIPTION
## Summary
- avoid fixed delay when waiting for gameplay

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6853cf7cae14832bbc32b86e54138448