### PR TITLE
Improve game start and gameplay balance

### DIFF
--- a/features/laser_firing.feature
+++ b/features/laser_firing.feature
@@ -1,7 +1,7 @@
 Feature: Laser firing
   Scenario: Holding left mouse button fires bullets and drains ammo
     Given I open the game page
-    When I click the start button
+    When I click the start screen
     Then the game should appear after a short delay
     When I hold the left mouse button for 300 ms
     Then bullets should be fired

--- a/features/level_progression.feature
+++ b/features/level_progression.feature
@@ -2,7 +2,7 @@ Feature: Level progression
   Scenario: Difficulty increases over time
     Given I open the game page
     And the level progression interval is 1000 ms
-    When I click the start button
+    When I click the start screen
     Then the game should appear after a short delay
     When I wait for 600 ms
     Then the level should be 6

--- a/features/music.feature
+++ b/features/music.feature
@@ -2,6 +2,6 @@ Feature: Background music
   Scenario: Music transitions from menu to gameplay
     Given I open the game page
     Then menu music should be playing
-    When I click the start button
+    When I click the start screen
     Then the game should appear after a short delay
     Then gameplay music should be playing

--- a/features/start_game.feature
+++ b/features/start_game.feature
@@ -1,6 +1,6 @@
 Feature: Start the game
   Scenario: Player starts the game from the intro screen
     Given I open the game page
-    When I click the start button
+    When I click the start screen
     Then the promo animation should be shown
     And the game should appear after a short delay

--- a/features/step_definitions/steps.js
+++ b/features/step_definitions/steps.js
@@ -54,8 +54,8 @@ Given('I open the game page', async () => {
   await page.goto('file://' + filePath);
 });
 
-When('I click the start button', async () => {
-  await page.click('#start-button');
+When('I click the start screen', async () => {
+  await page.click('#start-screen');
 });
 
 Then('the promo animation should be shown', async () => {

--- a/features/streak_feedback.feature
+++ b/features/streak_feedback.feature
@@ -1,7 +1,7 @@
 Feature: Streak feedback
   Scenario: Score scaling and streak announcement
     Given I open the game page
-    When I click the start button
+    When I click the start screen
     Then the game should appear after a short delay
     When I simulate hitting 5 red orbs
     Then the streak should be 5

--- a/features/thruster_boost.feature
+++ b/features/thruster_boost.feature
@@ -1,7 +1,7 @@
 Feature: Thruster Boost
   Scenario: Activating the thruster consumes fuel and shows flame
     Given I open the game page
-    When I click the start button
+    When I click the start screen
     Then the game should appear after a short delay
     When I hold the right mouse button for 300 ms
     Then the flame should be visible

--- a/features/urgent_countdown.feature
+++ b/features/urgent_countdown.feature
@@ -1,7 +1,7 @@
 Feature: Urgent countdown display
   Scenario: Timer turns urgent when less than 10 seconds remain
     Given I open the game page
-    When I click the start button
+    When I click the start screen
     And the game should appear after a short delay
     And I force the timer below ten seconds
     Then the screen should pulse red

--- a/index.html
+++ b/index.html
@@ -7,9 +7,8 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <div id="start-screen">
-        <button id="start-button">Start</button>
-    </div>
+    <div id="start-screen"></div>
+    <div id="game-over"></div>
     <div id="promo-animation">
         <img src="images/promo_animated.webp" alt="Promo Animation">
     </div>

--- a/main.js
+++ b/main.js
@@ -25,6 +25,13 @@
         window.audioElements = { menuMusic, playTracks, sfx };
         menuMusic.play().catch(() => {});
 
+        const gameOverBox = document.getElementById('game-over');
+        function showGameOver(msg) {
+            gameOverBox.textContent = msg;
+            gameOverBox.style.display = 'flex';
+            gameOverBox.onclick = () => window.location.reload();
+        }
+
         function playTick() {
             sfx.tick.currentTime = 0;
             sfx.tick.play().catch(() => {});
@@ -101,7 +108,7 @@
                 this.spawnOrb = (color, t) => {
                     const x = Phaser.Math.Between(0, this.scale.width);
                     const y = Phaser.Math.Between(0, this.scale.height);
-                    const radius = 10;
+                    const radius = 15;
                     const orb = this.add.circle(x, y, radius, color);
                     orb.setScale(0);
                     const angle = Phaser.Math.FloatBetween(0, Math.PI * 2);
@@ -219,8 +226,7 @@
                     window.currentGameplayMusic?.pause();
                     sfx.boost.pause();
                     sfx.boost.currentTime = 0;
-                    alert('Time Up!');
-                    window.location.reload();
+                    showGameOver('Game Over! Your time ran out.');
                     return;
                 }
                 if (this.timeRemaining <= 10 && !this.urgentStarted) {
@@ -244,7 +250,7 @@
                     const accel = 300;
                     this.velocity.x += Math.cos(noseAngle) * accel * deltaSeconds;
                     this.velocity.y += Math.sin(noseAngle) * accel * deltaSeconds;
-                    this.fuel -= 20 * deltaSeconds;
+                    this.fuel -= 15 * deltaSeconds;
                     if (this.fuel < 0) {
                         this.fuel = 0;
                         this.isBoosting = false;
@@ -360,8 +366,7 @@
                         window.currentGameplayMusic?.pause();
                         sfx.boost.pause();
                         sfx.boost.currentTime = 0;
-                        alert('Game Over');
-                        window.location.reload();
+                        showGameOver('Game Over! You died.');
                         return;
                     }
                 }
@@ -404,7 +409,7 @@
 
                 this.ship.x += this.velocity.x * deltaSeconds;
                 this.ship.y += this.velocity.y * deltaSeconds;
-                this.velocity.scale(0.99);
+                this.velocity.scale(0.995);
 
                 const width = this.scale.width;
                 const height = this.scale.height;
@@ -421,7 +426,7 @@
             }
         }
 
-        document.getElementById('start-button').addEventListener('click', function() {
+        document.getElementById('start-screen').addEventListener('click', function() {
             document.getElementById('start-screen').style.display = 'none';
             const promo = document.getElementById('promo-animation');
             promo.style.display = 'flex';

--- a/style.css
+++ b/style.css
@@ -3,6 +3,7 @@ body, html {
     padding: 0;
     width: 100%;
     height: 100%;
+    overflow: hidden;
 }
 #start-screen {
     position: absolute;
@@ -87,4 +88,21 @@ body.urgent {
     opacity: 0;
     pointer-events: none;
     transition: opacity 1s;
+}
+
+#game-over {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: none;
+    justify-content: center;
+    align-items: center;
+    background: rgba(0, 0, 0, 0.8);
+    color: #fff;
+    font-size: 48px;
+    font-family: Arial, sans-serif;
+    text-align: center;
+    cursor: pointer;
 }


### PR DESCRIPTION
## Summary
- remove the Start button and let the entire start screen start the game
- add fullscreen `#game-over` overlay shown on death or timeout
- prevent scrolling while playing
- enlarge orbs, tweak fuel usage and ship momentum
- update BDD tests to click the start screen instead of a button

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6853f8a8adf4832bb5d8719ef8e8af99