### PR TITLE
Improve BDD duration artifact

### DIFF
--- a/.github/workflows/bdd.yml
+++ b/.github/workflows/bdd.yml
@@ -24,18 +24,18 @@ jobs:
           npm test
           end=$(date +%s)
           echo $((end - start)) > duration.txt
-      - name: Upload duration
-        if: success()
-        uses: actions/upload-artifact@v4
-        with:
-          name: bdd-duration
-          path: duration.txt
       - name: Generate report
         if: success()
         env:
           WORKFLOW_FILE: bdd.yml
         run: |
           node scripts/generate-duration-report.js
+      - name: Upload duration data
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bdd-duration
+          path: duration.json
       - name: Upload report
         if: success()
         uses: actions/upload-artifact@v4

--- a/scripts/generate-duration-report.js
+++ b/scripts/generate-duration-report.js
@@ -76,6 +76,7 @@ async function main() {
     // ignore
   }
   durations.sort((a, b) => a.run_number - b.run_number);
+  fs.writeFileSync('duration.json', JSON.stringify(durations, null, 2));
   const html = `<!DOCTYPE html>
 <html>
 <head>


### PR DESCRIPTION
## Summary
- store previous BDD durations in `duration.json`
- upload the aggregated durations file as the `bdd-duration` artifact

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6853fc7c1fcc832ba3577208e574e6a7