### PR TITLE
Fix level start and add test

### DIFF
--- a/features/start_game.feature
+++ b/features/start_game.feature
@@ -4,3 +4,12 @@ Feature: Start the game
     When I click the start screen
     Then the promo animation should be shown
     And the game should appear after a short delay
+
+  Scenario: Game starts at level 1 after waiting on the start screen
+    Given I open the game page
+    When I wait for 1200 ms
+    And I click the start screen
+    Then the promo animation should be shown
+    And the game should appear after a short delay
+    And the level should be 1
+    And the time remaining should be 60

--- a/features/step_definitions/steps.js
+++ b/features/step_definitions/steps.js
@@ -203,10 +203,17 @@ Then('menu music should be playing', async () => {
   }
 });
 
-Then('gameplay music should be playing', async () => {
-  await page.waitForFunction(() => window.currentGameplayMusic);
-  const exists = await page.evaluate(() => !!window.currentGameplayMusic);
-  if (!exists) {
-    throw new Error('Gameplay music not initialized');
-  }
-});
+  Then('gameplay music should be playing', async () => {
+    await page.waitForFunction(() => window.currentGameplayMusic);
+    const exists = await page.evaluate(() => !!window.currentGameplayMusic);
+    if (!exists) {
+      throw new Error('Gameplay music not initialized');
+    }
+  });
+
+  Then('the time remaining should be {int}', async expected => {
+    const val = await page.evaluate(() => Math.ceil(window.gameScene.timeRemaining));
+    if (val !== expected) {
+      throw new Error(`Expected time remaining ${expected} but got ${val}`);
+    }
+  });

--- a/main.js
+++ b/main.js
@@ -65,7 +65,8 @@
 
                 this.level = 1;
                 this.levelDuration = levelDurationMs;
-                this.nextLevelTime = this.time.now + this.levelDuration;
+                this.startTime = null;
+                this.nextLevelTime = null;
                 this.levelBanner = document.getElementById('level-banner');
                 this.showLevelBanner = level => {
                     this.levelBanner.textContent = `Level ${level}`;
@@ -171,6 +172,10 @@
             }
 
             function update(time, delta) {
+                if (this.startTime === null) {
+                    this.startTime = time;
+                    this.nextLevelTime = time + this.levelDuration;
+                }
                 // Smoothly rotate the ship to face the pointer
                 const targetAngle = Phaser.Math.Angle.Between(
                     this.ship.x,


### PR DESCRIPTION
## Summary
- ensure level timing is initialized on first update
- add step to check remaining time in BDD tests
- test that waiting on the start screen still begins at level 1

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6854073b912c832bb20eed9830871c8a