### PR TITLE
Fix star background visibility

### DIFF
--- a/static/lib/main.js
+++ b/static/lib/main.js
@@ -14,7 +14,7 @@
                 parent: 'game',
                 width: window.innerWidth,
                 height: window.innerHeight,
-                backgroundColor: 'transparent',
+                transparent: true,
                 scene: {
                     create: create,
                     update: update


### PR DESCRIPTION
## Summary
- make the Phaser canvas transparent so the stars background shows through

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685412668ed4832bbd9680cb2b1e8c8b