### PR TITLE
Pause music and game in background

### DIFF
--- a/features/pause_on_hide.feature
+++ b/features/pause_on_hide.feature
@@ -1,0 +1,8 @@
+Feature: Pause when hidden
+  Scenario: Music and game pause when page is hidden
+    Given I open the game page
+    When I click the start screen
+    Then the game should appear after a short delay
+    And I hide the page
+    Then gameplay music should be paused
+    And the game should be paused

--- a/features/step_definitions/steps.js
+++ b/features/step_definitions/steps.js
@@ -211,6 +211,28 @@ Then('menu music should be playing', async () => {
     }
   });
 
+  When('I hide the page', async () => {
+    await page.evaluate(() => {
+      Object.defineProperty(document, 'hidden', { configurable: true, get: () => true });
+      Object.defineProperty(document, 'visibilityState', { configurable: true, get: () => 'hidden' });
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+  });
+
+  Then('gameplay music should be paused', async () => {
+    const paused = await page.evaluate(() => window.currentGameplayMusic?.paused);
+    if (!paused) {
+      throw new Error('Music was not paused');
+    }
+  });
+
+  Then('the game should be paused', async () => {
+    const paused = await page.evaluate(() => window.gamePaused);
+    if (!paused) {
+      throw new Error('Game not paused');
+    }
+  });
+
   Then('the time remaining should be {int}', async expected => {
     const val = await page.evaluate(() => Math.ceil(window.gameScene.timeRemaining));
     if (val !== expected) {

--- a/static/lib/main.js
+++ b/static/lib/main.js
@@ -1,4 +1,5 @@
         const { menuMusic, playTracks, sfx } = window.audioElements;
+        window.gamePaused = false;
 
         const gameOverBox = document.getElementById('game-over');
         function showGameOver(msg) {
@@ -417,3 +418,28 @@
                 startGame(window.levelDuration);
             }, 3000);
         });
+
+        function handleVisibility() {
+            if (document.hidden) {
+                menuMusic.pause();
+                window.currentGameplayMusic?.pause();
+                sfx.boost.pause();
+                sfx.boost.currentTime = 0;
+                if (window.gameScene) {
+                    window.gameScene.scene.pause();
+                    window.gamePaused = true;
+                }
+            } else {
+                if (window.gameScene) {
+                    window.gameScene.scene.resume();
+                    window.gamePaused = false;
+                }
+                if (document.getElementById('start-screen').style.display !== 'none') {
+                    menuMusic.play().catch(() => {});
+                } else if (window.currentGameplayMusic) {
+                    window.currentGameplayMusic.play().catch(() => {});
+                }
+            }
+        }
+
+        document.addEventListener('visibilitychange', handleVisibility);


### PR DESCRIPTION
## Summary
- stop music and pause gameplay when tab is hidden
- add feature for pausing when hidden
- add steps to handle hiding the page and checking paused state

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6854147eda2c832b8357e67693bb5fe4