### PR TITLE
Add concurrency to BDD workflow

### DIFF
--- a/.github/workflows/bdd.yml
+++ b/.github/workflows/bdd.yml
@@ -4,6 +4,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add a concurrency block to the BDD workflow so only one run executes at a time

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68541509e18c832b8262758d05c8f612