### PR TITLE
Hide legend until game start

### DIFF
--- a/features/start_game.feature
+++ b/features/start_game.feature
@@ -20,6 +20,10 @@ Feature: Start the game
     Then the game should appear after a short delay
     And the star background should cover the game area
 
+  Scenario: Legend hidden before starting the game
+    Given I open the game page
+    Then the legend should not be visible
+
   Scenario: Legend displayed on start
     Given I open the game page
     When I click the start screen

--- a/features/step_definitions/steps.js
+++ b/features/step_definitions/steps.js
@@ -257,6 +257,13 @@ Then('menu music should be playing', async () => {
     }
   });
 
+  Then('the legend should not be visible', async () => {
+    const display = await page.$eval('#legend', el => getComputedStyle(el).display);
+    if (display !== 'none') {
+      throw new Error('Legend should be hidden');
+    }
+  });
+
   When('I move the pointer to offset {int} {int}', async (dx, dy) => {
     await page.waitForFunction(() => window.gameScene);
     const canvas = await page.waitForSelector('#game canvas', { state: 'attached' });

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -115,6 +115,7 @@ body.urgent {
     color: #fff;
     font-family: Arial, sans-serif;
     font-size: 14px;
+    display: none;
 }
 
 .legend-dot {

--- a/static/lib/main.js
+++ b/static/lib/main.js
@@ -26,6 +26,7 @@
             document.getElementById('fuel-container').style.display = 'block';
             document.getElementById('ammo-container').style.display = 'block';
             document.getElementById('score-container').style.display = 'block';
+            document.getElementById('legend').style.display = 'block';
 
             window.addEventListener('resize', function () {
                 game.scale.resize(window.innerWidth, window.innerHeight);


### PR DESCRIPTION
## Summary
- hide #legend on the start screen via CSS
- display the legend when gameplay starts
- add BDD scenario ensuring the legend is hidden initially
- add test step to confirm legend hidden

## Testing
- `npm run check`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685419e9918c832b9217aa2c13b05dfa