### PR TITLE
Add planets and improve visuals

### DIFF
--- a/features/planet_hazards.feature
+++ b/features/planet_hazards.feature
@@ -1,0 +1,7 @@
+Feature: Planet hazards
+  Scenario: Ship crashes into a planet
+    Given I open the game page
+    When I click the start screen
+    Then the game should appear after a short delay
+    When I spawn a planet on the ship
+    Then the game should be over

--- a/features/step_definitions/steps.js
+++ b/features/step_definitions/steps.js
@@ -95,7 +95,7 @@ Then('the flame should be visible', async () => {
 
 Then('the fuel should decrease', async () => {
   const fuel = await page.evaluate(() => window.gameScene.fuel);
-  if (fuel >= 150) {
+  if (fuel >= 200) {
     throw new Error('Fuel did not decrease');
   }
 });
@@ -309,4 +309,17 @@ Then('menu music should be playing', async () => {
     if (ammo !== initialAmmo + 15) {
       throw new Error('Ammo did not increase by 15');
     }
+  });
+
+  When('I spawn a planet on the ship', async () => {
+    await page.waitForFunction(() => window.gameScene && window.gameScene.planets);
+    await page.evaluate(() => {
+      const gs = window.gameScene;
+      const p = gs.add.circle(gs.ship.x, gs.ship.y, 60, 0x6666ff);
+      gs.planets.push({ sprite: p, radius: 60 });
+    });
+  });
+
+  Then('the game should be over', async () => {
+    await page.waitForFunction(() => window.gameScene?.gameOver);
   });

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -51,6 +51,12 @@ body, html {
     width: 100%;
     height: 100%;
     background: orange;
+    text-align: center;
+    font-family: Arial, sans-serif;
+    font-size: 10px;
+    line-height: 10px;
+    color: #000;
+    overflow: hidden;
 }
 #ammo-container {
     position: absolute;


### PR DESCRIPTION
## Summary
- make fuel display text percentage
- randomly spawn large planet obstacles
- make balls and bullets larger
- crash objects when colliding with planets
- increase starting fuel and adjust consumption
- add BDD test for planet hazards

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68541b006164832b9c13a3992669800b