### PR TITLE
Add browser high score tracking

### DIFF
--- a/features/highscore.feature
+++ b/features/highscore.feature
@@ -1,0 +1,14 @@
+Feature: High score tracking
+  Scenario: High score shown when starting the game
+    Given I open the game page
+    Then the high score should be 0
+
+  Scenario: High score saved after a game
+    Given I open the game page
+    When I click the start screen
+    Then the game should appear after a short delay
+    When I simulate hitting 1 red orbs
+    And I spawn a planet on the ship
+    Then the game should be over
+    When I reload the page
+    Then the high score should be 10

--- a/features/step_definitions/steps.js
+++ b/features/step_definitions/steps.js
@@ -323,3 +323,14 @@ Then('menu music should be playing', async () => {
   Then('the game should be over', async () => {
     await page.waitForFunction(() => window.gameScene?.gameOver);
   });
+
+  When('I reload the page', async () => {
+    await page.reload({ waitUntil: 'load' });
+  });
+
+  Then('the high score should be {int}', async expected => {
+    const val = await page.$eval('#highscore-value', el => parseInt(el.textContent));
+    if (val !== expected) {
+      throw new Error(`Expected high score ${expected} but got ${val}`);
+    }
+  });

--- a/index.html
+++ b/index.html
@@ -7,7 +7,9 @@
     <link rel="stylesheet" href="static/css/style.css">
 </head>
 <body>
-    <div id="start-screen"></div>
+    <div id="start-screen">
+        <div id="highscore-display">Your highscore: <span id="highscore-value">0</span></div>
+    </div>
     <div id="game-over"></div>
     <div id="promo-animation">
         <img src="static/images/promo_animated.webp" alt="Promo Animation">

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -16,6 +16,15 @@ body, html {
     align-items: center;
     background: url('../images/promo.webp') center center / cover no-repeat;
 }
+#highscore-display {
+    position: absolute;
+    bottom: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    color: #fff;
+    font-family: Arial, sans-serif;
+    font-size: 24px;
+}
 #promo-animation {
     position: absolute;
     top: 0;

--- a/static/lib/main.js
+++ b/static/lib/main.js
@@ -1,8 +1,16 @@
         const { menuMusic, playTracks, sfx } = window.audioElements;
         window.gamePaused = false;
 
+        const storedHigh = parseInt(localStorage.getItem('highscore') || '0');
+        document.getElementById('highscore-value').textContent = storedHigh;
+
         const gameOverBox = document.getElementById('game-over');
         function showGameOver(msg) {
+            const finalScore = window.gameScene?.score || 0;
+            const prev = parseInt(localStorage.getItem('highscore') || '0');
+            if (finalScore > prev) {
+                localStorage.setItem('highscore', finalScore);
+            }
             gameOverBox.textContent = msg;
             gameOverBox.style.display = 'flex';
             gameOverBox.onclick = () => window.location.reload();


### PR DESCRIPTION
## Summary
- add highscore text on the start page
- style the highscore display
- persist highscore in localStorage and update when the game ends
- add step definitions for reloading and checking the highscore
- cover the feature with new BDD scenarios

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68541cd80dfc832b92dac726ddfd8215