### PR TITLE
Shrink orb radius for better dodging

### DIFF
--- a/features/step_definitions/steps.js
+++ b/features/step_definitions/steps.js
@@ -359,9 +359,9 @@ When('I spawn a stationary red orb offset by {int} {int} from the ship', async (
   await page.waitForFunction(() => window.gameScene && window.gameScene.orbs);
   await page.evaluate(({ dx, dy }) => {
     const gs = window.gameScene;
-    const orb = gs.add.circle(gs.ship.x + dx, gs.ship.y + dy, 25, 0xff0000);
+    const orb = gs.add.circle(gs.ship.x + dx, gs.ship.y + dy, 20, 0xff0000);
     orb.setScale(1);
-    gs.orbs.push({ sprite: orb, radius: 25, vx: 0, vy: 0, spawnTime: gs.time.now, growing: false });
+    gs.orbs.push({ sprite: orb, radius: 20, vx: 0, vy: 0, spawnTime: gs.time.now, growing: false });
   }, { dx, dy });
   await new Promise(r => setTimeout(r, 100));
 });

--- a/static/lib/main.js
+++ b/static/lib/main.js
@@ -106,7 +106,7 @@
                 this.spawnOrb = (color, t) => {
                     const x = Phaser.Math.Between(0, this.scale.width);
                     const y = Phaser.Math.Between(0, this.scale.height);
-                    const radius = 25;
+                    const radius = 20;
                     const orb = this.add.circle(x, y, radius, color);
                     orb.setScale(0);
                     const angle = Phaser.Math.FloatBetween(0, Math.PI * 2);


### PR DESCRIPTION
## Summary
- make drifting orbs slightly smaller
- adjust test step definitions for new size

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68544b732184832b9974393a54fe5f24