### PR TITLE
Add planetary atmosphere visuals

### DIFF
--- a/features/orb_gravity.feature
+++ b/features/orb_gravity.feature
@@ -4,8 +4,8 @@ Feature: Orb gravitational pull
     When I click the start screen
     Then the game should appear after a short delay
     And I clear existing orbs
-    And I spawn a planet offset by 120 0 from the ship
-    And I spawn a stationary red orb offset by 250 0 from the ship
+    And I spawn a planet offset by 140 0 from the ship
+    And I spawn a stationary red orb offset by 270 0 from the ship
     And I record the orb position
-    And I wait for 500 ms
+    And I wait for 1000 ms
     Then the orb should have moved

--- a/features/planet_gravity.feature
+++ b/features/planet_gravity.feature
@@ -5,6 +5,6 @@ Feature: Planetary gravity
     Then the game should appear after a short delay
     When I record the ship position
     And I spawn a planet offset by 140 0 from the ship
-    Then the planet radius should be 80
-    And I wait for 1000 ms
+    Then the planet radius should be 100
+    And I wait for 1500 ms
     Then the ship should have moved

--- a/features/step_definitions/steps.js
+++ b/features/step_definitions/steps.js
@@ -315,18 +315,50 @@ Then('menu music should be playing', async () => {
     await page.waitForFunction(() => window.gameScene && window.gameScene.planets);
     await page.evaluate(() => {
       const gs = window.gameScene;
-      const p = gs.add.circle(gs.ship.x, gs.ship.y, 80, 0x6666ff);
-      gs.planets.push({ sprite: p, radius: 80 });
+      const pr = 100;
+      const atmoKey = `bdd-atmo-${gs.planets.length}`;
+      const atmoRadius = pr * 1.5;
+      const size = atmoRadius * 2;
+      const tex = gs.textures.createCanvas(atmoKey, size, size);
+      const ctx = tex.getContext();
+      const grad = ctx.createRadialGradient(size / 2, size / 2, pr, size / 2, size / 2, atmoRadius);
+      grad.addColorStop(0, 'rgba(102,102,255,0.4)');
+      grad.addColorStop(1, 'rgba(102,102,255,0)');
+      ctx.fillStyle = grad;
+      ctx.beginPath();
+      ctx.arc(size / 2, size / 2, atmoRadius, 0, Math.PI * 2);
+      ctx.fill();
+      tex.refresh();
+      const atmo = gs.add.image(gs.ship.x, gs.ship.y, atmoKey);
+      atmo.setDepth(-1);
+      const p = gs.add.circle(gs.ship.x, gs.ship.y, pr, 0x6666ff);
+      gs.planets.push({ sprite: p, radius: pr, atmosphere: atmo });
     });
   });
 
   When('I spawn a planet offset by {int} {int} from the ship', async (dx, dy) => {
     await page.waitForFunction(() => window.gameScene && window.gameScene.planets);
-    await page.evaluate(({ dx, dy }) => {
-      const gs = window.gameScene;
-      const p = gs.add.circle(gs.ship.x + dx, gs.ship.y + dy, 80, 0x6666ff);
-      gs.planets.push({ sprite: p, radius: 80 });
-    }, { dx, dy });
+  await page.evaluate(({ dx, dy }) => {
+    const gs = window.gameScene;
+    const pr = 100;
+    const atmoKey = `bdd-atmo-${gs.planets.length}`;
+    const atmoRadius = pr * 1.5;
+    const size = atmoRadius * 2;
+    const tex = gs.textures.createCanvas(atmoKey, size, size);
+    const ctx = tex.getContext();
+    const grad = ctx.createRadialGradient(size / 2, size / 2, pr, size / 2, size / 2, atmoRadius);
+    grad.addColorStop(0, 'rgba(102,102,255,0.4)');
+    grad.addColorStop(1, 'rgba(102,102,255,0)');
+    ctx.fillStyle = grad;
+    ctx.beginPath();
+    ctx.arc(size / 2, size / 2, atmoRadius, 0, Math.PI * 2);
+    ctx.fill();
+    tex.refresh();
+    const atmo = gs.add.image(gs.ship.x + dx, gs.ship.y + dy, atmoKey);
+    atmo.setDepth(-1);
+    const p = gs.add.circle(gs.ship.x + dx, gs.ship.y + dy, pr, 0x6666ff);
+    gs.planets.push({ sprite: p, radius: pr, atmosphere: atmo });
+  }, { dx, dy });
   });
 
   Then('the planet radius should be {int}', async expected => {

--- a/static/lib/main.js
+++ b/static/lib/main.js
@@ -92,15 +92,31 @@
                 // Planet obstacles
                 this.planets = [];
                 this.gravityStrength = 3000;
-                const pr = 80;
+                const pr = 100;
                 const positions = [
-                    { x: 80, y: 80 },
-                    { x: this.scale.width - 80, y: 80 },
-                    { x: this.scale.width / 2, y: this.scale.height - 80 }
+                    { x: pr, y: pr },
+                    { x: this.scale.width - pr, y: pr },
+                    { x: this.scale.width / 2, y: this.scale.height - pr }
                 ];
-                for (const pos of positions) {
+                for (let i = 0; i < positions.length; i++) {
+                    const pos = positions[i];
+                    const atmoKey = `atmo-${i}`;
+                    const atmoRadius = pr * 1.5;
+                    const size = atmoRadius * 2;
+                    const tex = this.textures.createCanvas(atmoKey, size, size);
+                    const ctx = tex.getContext();
+                    const grad = ctx.createRadialGradient(size / 2, size / 2, pr, size / 2, size / 2, atmoRadius);
+                    grad.addColorStop(0, 'rgba(102,102,255,0.4)');
+                    grad.addColorStop(1, 'rgba(102,102,255,0)');
+                    ctx.fillStyle = grad;
+                    ctx.beginPath();
+                    ctx.arc(size / 2, size / 2, atmoRadius, 0, Math.PI * 2);
+                    ctx.fill();
+                    tex.refresh();
+                    const atmosphere = this.add.image(pos.x, pos.y, atmoKey);
+                    atmosphere.setDepth(-1);
                     const planet = this.add.circle(pos.x, pos.y, pr, 0x6666ff);
-                    this.planets.push({ sprite: planet, radius: pr });
+                    this.planets.push({ sprite: planet, radius: pr, atmosphere });
                 }
 
                 this.spawnOrb = (color, t) => {


### PR DESCRIPTION
## Summary
- enlarge planets and surround them with atmospheric glow
- update step definitions to create atmospheres in tests
- adjust gravity-related features for new planet size

## Testing
- `npm run check`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68544fc3bf1c832ba266c2dffe456c38