### PR TITLE
Enhance power-up visuals and duration

### DIFF
--- a/features/powerup_pickup.feature
+++ b/features/powerup_pickup.feature
@@ -5,3 +5,13 @@ Feature: Power-up pickups
     Then the game should appear after a short delay
     When I spawn an ammo power-up on the ship
     Then the ammo should increase by 15
+
+  Scenario: Power-ups linger before fading
+    Given I open the game page
+    When I click the start screen
+    Then the game should appear after a short delay
+    When I spawn an ammo power-up offset by 100 0 from the ship
+    When I wait for 7000 ms
+    Then a power-up should be visible
+    When I wait for 3000 ms
+    Then no power-ups should be visible

--- a/features/step_definitions/steps.js
+++ b/features/step_definitions/steps.js
@@ -298,9 +298,28 @@ Then('menu music should be playing', async () => {
     await page.evaluate(() => {
       const gs = window.gameScene;
       const time = gs.time.now;
-      const pu = gs.add.circle(gs.ship.x, gs.ship.y, 8, 0xffff00);
-      gs.powerUps.push({ sprite: pu, type: 'ammo', spawnTime: time });
+      const chest = gs.add.container(gs.ship.x, gs.ship.y);
+      const base = gs.add.rectangle(0, 3, 20, 11, 0x8b4513);
+      const lid = gs.add.rectangle(0, -4, 20, 6, 0xffff00);
+      chest.add([base, lid]);
+      gs.powerUps.push({ sprite: chest, type: 'ammo', spawnTime: time });
+      gs.nextPowerUpSpawn = Infinity;
     });
+    await page.waitForTimeout(200);
+  });
+
+  When('I spawn an ammo power-up offset by {int} {int} from the ship', async (dx, dy) => {
+    await page.waitForFunction(() => window.gameScene && window.gameScene.powerUps);
+    await page.evaluate(({ dx, dy }) => {
+      const gs = window.gameScene;
+      const time = gs.time.now;
+      const chest = gs.add.container(gs.ship.x + dx, gs.ship.y + dy);
+      const base = gs.add.rectangle(0, 3, 20, 11, 0x8b4513);
+      const lid = gs.add.rectangle(0, -4, 20, 6, 0xffff00);
+      chest.add([base, lid]);
+      gs.powerUps.push({ sprite: chest, type: 'ammo', spawnTime: time });
+      gs.nextPowerUpSpawn = Infinity;
+    }, { dx, dy });
     await page.waitForTimeout(200);
   });
 
@@ -308,6 +327,20 @@ Then('menu music should be playing', async () => {
     const ammo = await page.evaluate(() => window.gameScene.ammo);
     if (ammo !== initialAmmo + 15) {
       throw new Error('Ammo did not increase by 15');
+    }
+  });
+
+  Then('a power-up should be visible', async () => {
+    const count = await page.evaluate(() => window.gameScene.powerUps.length);
+    if (count === 0) {
+      throw new Error('Power-up not visible');
+    }
+  });
+
+  Then('no power-ups should be visible', async () => {
+    const count = await page.evaluate(() => window.gameScene.powerUps.length);
+    if (count !== 0) {
+      throw new Error('Power-up still visible');
     }
   });
 

--- a/static/lib/main.js
+++ b/static/lib/main.js
@@ -64,7 +64,7 @@
                 this.floatingTexts = [];
                 this.nextPowerUpSpawn = 5000;
                 this.powerUpSpawnRate = 8000; // milliseconds
-                this.powerUpFadeDuration = 6000;
+                this.powerUpFadeDuration = 9000;
                 this.urgentStarted = false;
                 this.urgentInterval = null;
 
@@ -341,9 +341,12 @@
                     let color = 0xffff00;
                     if (type === 'fuel') color = 0xffa500;
                     if (type === 'time') color = 0x00ff00;
-                    const pu = this.add.circle(x, y, 8, color);
-                    pu.setAlpha(1);
-                    this.powerUps.push({ sprite: pu, type: type, spawnTime: time });
+                    const chest = this.add.container(x, y);
+                    const base = this.add.rectangle(0, 3, 20, 11, 0x8b4513);
+                    const lid = this.add.rectangle(0, -4, 20, 6, color);
+                    chest.add([base, lid]);
+                    chest.setAlpha(1);
+                    this.powerUps.push({ sprite: chest, type: type, spawnTime: time });
                     this.nextPowerUpSpawn = time + this.powerUpSpawnRate;
                 }
 


### PR DESCRIPTION
## Summary
- increase power-up fade time
- spawn chest-style power-ups instead of circles
- update BDD step definitions for chest power-ups
- ensure power-ups stay longer with new tests

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68545107f91c832b93afa791fed52260