### PR TITLE
Implement shop tab on start screen

### DIFF
--- a/features/shop.feature
+++ b/features/shop.feature
@@ -1,0 +1,5 @@
+Feature: Shop access
+  Scenario: Open shop from the start screen
+    Given I open the game page
+    When I open the shop tab
+    Then the shop should list upgrades

--- a/features/step_definitions/steps.js
+++ b/features/step_definitions/steps.js
@@ -499,3 +499,11 @@ Then('the ship speed should be below {int}', async max => {
     throw new Error(`Ship speed ${speed} not below ${max}`);
   }
 });
+
+When('I open the shop tab', async () => {
+  await page.click('#shop-tab');
+});
+
+Then('the shop should list upgrades', async () => {
+  await page.waitForSelector('#shop-panel .shop-item');
+});

--- a/index.html
+++ b/index.html
@@ -20,6 +20,14 @@
             <p>Click anywhere to begin!</p>
         </div>
         <div id="highscore-display">Your highscore: <span id="highscore-value">0</span></div>
+        <div id="start-credits-display">Credits: <span id="start-credits-value">0</span></div>
+        <div id="shop-tab">Shop</div>
+        <div id="shop-panel">
+            <h2>Shop</h2>
+            <div id="shop-items"></div>
+            <div id="shop-credits">Credits: <span class="total-credits">0</span></div>
+            <button id="close-shop">Close</button>
+        </div>
     </div>
     <div id="game-over"></div>
     <div id="promo-animation">

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -25,6 +25,40 @@ body, html {
     font-family: Arial, sans-serif;
     font-size: 24px;
 }
+#start-credits-display {
+    position: absolute;
+    bottom: 60px;
+    left: 50%;
+    transform: translateX(-50%);
+    color: #fff;
+    font-family: Arial, sans-serif;
+    font-size: 20px;
+}
+#shop-tab {
+    position: absolute;
+    top: 20px;
+    right: 20px;
+    background: rgba(0, 0, 0, 0.7);
+    color: #fff;
+    padding: 8px 12px;
+    border-radius: 4px;
+    cursor: pointer;
+}
+#shop-panel {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: rgba(0, 0, 0, 0.8);
+    color: #fff;
+    padding: 20px;
+    display: none;
+    text-align: left;
+    border-radius: 8px;
+}
+.shop-item {
+    margin-bottom: 10px;
+}
 #promo-animation {
     position: absolute;
     top: 0;

--- a/static/lib/main.js
+++ b/static/lib/main.js
@@ -3,6 +3,40 @@
 
         const storedHigh = parseInt(localStorage.getItem('highscore') || '0');
         document.getElementById('highscore-value').textContent = storedHigh;
+        window.totalCredits = parseInt(localStorage.getItem('credits') || '0');
+        document.querySelectorAll('.total-credits, #start-credits-value').forEach(el => {
+            el.textContent = window.totalCredits;
+        });
+
+        const shopItems = [
+            { id: 'max_ammo', name: 'Increase Max Ammo', cost: 5, permanent: true },
+            { id: 'shield', name: 'Temporary Shield', cost: 2, stock: 1 }
+        ];
+
+        function renderShop() {
+            const container = document.getElementById('shop-items');
+            container.innerHTML = '';
+            shopItems.forEach(item => {
+                const div = document.createElement('div');
+                div.className = 'shop-item';
+                const btn = document.createElement('button');
+                btn.textContent = `Buy (${item.cost})`;
+                btn.onclick = () => purchase(item);
+                div.textContent = `${item.name} - ${item.cost} credits `;
+                div.appendChild(btn);
+                container.appendChild(div);
+            });
+        }
+
+        function purchase(item) {
+            if (window.totalCredits >= item.cost) {
+                window.totalCredits -= item.cost;
+                localStorage.setItem('credits', window.totalCredits);
+                document.querySelectorAll('.total-credits, #start-credits-value').forEach(el => {
+                    el.textContent = window.totalCredits;
+                });
+            }
+        }
 
         const gameOverBox = document.getElementById('game-over');
         function showGameOver(msg) {
@@ -150,6 +184,11 @@
                         this.streak += 1;
                         this.score += 10 * this.streak;
                         this.credits += 1;
+                        window.totalCredits += 1;
+                        localStorage.setItem('credits', window.totalCredits);
+                        document.querySelectorAll('.total-credits, #start-credits-value').forEach(el => {
+                            el.textContent = window.totalCredits;
+                        });
                         if (this.streak % 5 === 0) {
                             const txt = this.add.text(x, y, `Streak ${this.streak}!`, { font: '20px Arial', color: '#ff00ff' });
                             txt.setOrigin(0.5);
@@ -522,7 +561,18 @@
             }
         }
 
-        document.getElementById('start-screen').addEventListener('click', function() {
+        document.getElementById('shop-tab').addEventListener('click', () => {
+            renderShop();
+            document.getElementById('shop-panel').style.display = 'block';
+        });
+        document.getElementById('close-shop').addEventListener('click', () => {
+            document.getElementById('shop-panel').style.display = 'none';
+        });
+
+        document.getElementById('start-screen').addEventListener('click', function(e) {
+            if (e.target.id === 'shop-tab' || e.target.closest('#shop-panel')) {
+                return;
+            }
             document.getElementById('start-screen').style.display = 'none';
             const promo = document.getElementById('promo-animation');
             promo.style.display = 'flex';


### PR DESCRIPTION
## Summary
- add Shop tab and panel in the start screen
- style shop elements
- persist credits and manage shop purchases
- update main game logic for credits and shop
- add BDD scenario for shop access

## Testing
- `npm run check`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685457c4a2a8832ba485fc352725cbc4