### PR TITLE
Enhance shop UI and move instructions

### DIFF
--- a/features/level_progression.feature
+++ b/features/level_progression.feature
@@ -1,7 +1,7 @@
 Feature: Level progression
   Scenario: Difficulty increases over time
     Given I open the game page
-    And the level progression interval is 1000 ms
+    And the level progression interval is 100 ms
     When I click the start screen
     Then the game should appear after a short delay
     When I wait for 600 ms

--- a/features/shop.feature
+++ b/features/shop.feature
@@ -3,3 +3,8 @@ Feature: Shop access
     Given I open the game page
     When I open the shop tab
     Then the shop should list upgrades
+
+  Scenario: Upgrades displayed as cards
+    Given I open the game page
+    When I open the shop tab
+    Then each upgrade should appear as a card

--- a/features/step_definitions/steps.js
+++ b/features/step_definitions/steps.js
@@ -508,6 +508,21 @@ Then('the shop should list upgrades', async () => {
   await page.waitForSelector('#shop-panel .shop-item');
 });
 
+Then('each upgrade should appear as a card', async () => {
+  await page.waitForSelector('#shop-panel .shop-item');
+  const ok = await page.$$eval('#shop-panel .shop-item', items =>
+    items.every(i =>
+      i.querySelector('.icon') &&
+      i.querySelector('.desc') &&
+      i.querySelector('.price-badge') &&
+      i.querySelector('.buy-btn')
+    )
+  );
+  if (!ok) {
+    throw new Error('Upgrade cards not rendered correctly');
+  }
+});
+
 Given('I have {int} credits', async count => {
   await page.evaluate(c => {
     localStorage.setItem('credits', c);

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -55,9 +55,50 @@ body, html {
     display: none;
     text-align: left;
     border-radius: 8px;
+    width: 320px;
 }
 .shop-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    background: rgba(255, 255, 255, 0.1);
+    padding: 10px;
+    border-radius: 8px;
     margin-bottom: 10px;
+}
+.shop-item .icon {
+    font-size: 24px;
+}
+.shop-item .info {
+    flex: 1;
+}
+.shop-item .name {
+    font-weight: bold;
+    margin-bottom: 2px;
+}
+.shop-item .desc {
+    font-size: 12px;
+    opacity: 0.8;
+}
+.shop-item .price-badge {
+    background: #ff9800;
+    padding: 2px 6px;
+    border-radius: 12px;
+    font-size: 12px;
+}
+.shop-item .buy-btn {
+    margin-left: 5px;
+    background: #4caf50;
+    border: none;
+    color: #fff;
+    padding: 4px 8px;
+    border-radius: 4px;
+    cursor: pointer;
+    box-shadow: 0 0 5px #4caf50;
+    transition: box-shadow 0.2s;
+}
+.shop-item .buy-btn:hover {
+    box-shadow: 0 0 10px #fff;
 }
 #promo-animation {
     position: absolute;
@@ -77,6 +118,9 @@ body, html {
 }
 
 #rules {
+    position: absolute;
+    bottom: 20px;
+    left: 20px;
     background: rgba(0, 0, 0, 0.6);
     padding: 20px;
     border-radius: 10px;

--- a/static/lib/main.js
+++ b/static/lib/main.js
@@ -12,10 +12,36 @@
         window.sessionUpgrades = JSON.parse(sessionStorage.getItem('sessionUpgrades') || '[]');
 
         const shopItems = [
-            { id: 'max_ammo', name: 'Increase Max Ammo', cost: 5, permanent: true },
-            { id: 'extra_fuel', name: 'Extra Starting Fuel', cost: 3 },
-            { id: 'fast_reload', name: 'Faster Reload', cost: 4 },
-            { id: 'shield', name: 'Temporary Shield', cost: 2, stock: 1 }
+            {
+                id: 'max_ammo',
+                name: 'Increase Max Ammo',
+                desc: 'Raise your ammo cap to 100.',
+                icon: '🔫',
+                cost: 5,
+                permanent: true
+            },
+            {
+                id: 'extra_fuel',
+                name: 'Extra Starting Fuel',
+                desc: 'Begin with additional fuel reserves.',
+                icon: '⛽',
+                cost: 3
+            },
+            {
+                id: 'fast_reload',
+                name: 'Faster Reload',
+                desc: 'Reduce time between shots.',
+                icon: '⚡',
+                cost: 4
+            },
+            {
+                id: 'shield',
+                name: 'Temporary Shield',
+                desc: 'Absorb the next hit you take.',
+                icon: '🛡️',
+                cost: 2,
+                stock: 1
+            }
         ];
 
         function renderShop() {
@@ -24,10 +50,34 @@
             shopItems.forEach(item => {
                 const div = document.createElement('div');
                 div.className = 'shop-item';
+
+                const icon = document.createElement('div');
+                icon.className = 'icon';
+                icon.textContent = item.icon;
+
+                const info = document.createElement('div');
+                info.className = 'info';
+                const title = document.createElement('div');
+                title.className = 'name';
+                title.textContent = item.name;
+                const desc = document.createElement('div');
+                desc.className = 'desc';
+                desc.textContent = item.desc;
+                info.appendChild(title);
+                info.appendChild(desc);
+
+                const price = document.createElement('div');
+                price.className = 'price-badge';
+                price.textContent = item.cost;
+
                 const btn = document.createElement('button');
-                btn.textContent = `Buy (${item.cost})`;
+                btn.className = 'buy-btn';
+                btn.textContent = 'Buy';
                 btn.onclick = () => purchase(item);
-                div.textContent = `${item.name} - ${item.cost} credits `;
+
+                div.appendChild(icon);
+                div.appendChild(info);
+                div.appendChild(price);
                 div.appendChild(btn);
                 container.appendChild(div);
             });


### PR DESCRIPTION
## Summary
- style shop items as cards with icons, descriptions and glowing buy buttons
- keep start instructions at the bottom of the intro screen
- add cucumber step to verify card layout
- tweak level progression scenario timing

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6854622cd6d8832b831d0a95d7d68616