### PR TITLE
Add inventory panel to start screen

### DIFF
--- a/features/inventory_panel.feature
+++ b/features/inventory_panel.feature
@@ -1,0 +1,8 @@
+Feature: Inventory panel
+  Scenario: Baseline stats displayed on the start screen
+    Given I open the game page
+    Then the inventory panel should be visible
+    And the inventory stat "Fuel Capacity" should be "200"
+    And the inventory stat "Ammo Limit" should be "50"
+    And the inventory stat "Boost Thrust" should be "200"
+    And the inventory stat "Shield Duration" should be "0"

--- a/features/step_definitions/steps.js
+++ b/features/step_definitions/steps.js
@@ -568,3 +568,21 @@ Then('the game should not be over', async () => {
     throw new Error('Game should not be over');
   }
 });
+
+Then('the inventory panel should be visible', async () => {
+  const display = await page.$eval('#inventory-panel', el => getComputedStyle(el).display);
+  if (display === 'none') {
+    throw new Error('Inventory panel not visible');
+  }
+});
+
+Then('the inventory stat {string} should be {string}', async (label, expected) => {
+  const actual = await page.evaluate(lbl => {
+    const items = Array.from(document.querySelectorAll('#inventory-panel li'));
+    const el = items.find(i => i.textContent.trim().toLowerCase().startsWith(lbl.toLowerCase()));
+    return el ? el.querySelector('span').textContent.trim() : null;
+  }, label);
+  if (actual !== expected) {
+    throw new Error(`Expected ${label} ${expected} but got ${actual}`);
+  }
+});

--- a/index.html
+++ b/index.html
@@ -28,6 +28,15 @@
             <div id="shop-credits">Credits: <span class="total-credits">0</span></div>
             <button id="close-shop">Close</button>
         </div>
+        <div id="inventory-panel">
+            <h2>Ship Stats</h2>
+            <ul>
+                <li>Fuel Capacity: <span id="inv-fuel">0</span></li>
+                <li>Ammo Limit: <span id="inv-ammo">0</span></li>
+                <li>Boost Thrust: <span id="inv-thrust">0</span></li>
+                <li>Shield Duration: <span id="inv-shield">0</span></li>
+            </ul>
+        </div>
     </div>
     <div id="game-over"></div>
     <div id="promo-animation">

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -57,6 +57,34 @@ body, html {
     border-radius: 8px;
     width: 320px;
 }
+
+#inventory-panel {
+    position: absolute;
+    top: 20px;
+    left: 20px;
+    background: rgba(0, 0, 0, 0.6);
+    color: #fff;
+    padding: 10px 15px;
+    border-radius: 8px;
+    font-family: Arial, sans-serif;
+}
+
+#inventory-panel h2 {
+    margin-top: 0;
+    text-align: center;
+    font-size: 18px;
+}
+
+#inventory-panel ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+#inventory-panel li {
+    font-size: 14px;
+    margin-bottom: 4px;
+}
 .shop-item {
     display: flex;
     align-items: center;

--- a/static/lib/main.js
+++ b/static/lib/main.js
@@ -11,6 +11,29 @@
         window.permanentUpgrades = JSON.parse(localStorage.getItem('permanentUpgrades') || '[]');
         window.sessionUpgrades = JSON.parse(sessionStorage.getItem('sessionUpgrades') || '[]');
 
+        window.baseStats = {
+            maxFuel: 200,
+            ammo: 50,
+            boostThrust: 200,
+            shieldDuration: 0
+        };
+
+        function updateInventoryPanel() {
+            let fuel = window.baseStats.maxFuel;
+            let ammo = window.baseStats.ammo;
+            let thrust = window.baseStats.boostThrust;
+            let shield = window.baseStats.shieldDuration;
+            const active = new Set([...window.permanentUpgrades, ...window.sessionUpgrades]);
+            if (active.has('extra_fuel')) fuel += 50;
+            if (active.has('max_ammo')) ammo = 100;
+            document.getElementById('inv-fuel').textContent = fuel;
+            document.getElementById('inv-ammo').textContent = ammo;
+            document.getElementById('inv-thrust').textContent = thrust;
+            document.getElementById('inv-shield').textContent = shield;
+        }
+
+        updateInventoryPanel();
+
         const shopItems = [
             {
                 id: 'max_ammo',
@@ -101,6 +124,7 @@
                 }
                 if (item.stock) item.stock -= 1;
                 renderShop();
+                updateInventoryPanel();
             }
         }
 
@@ -151,9 +175,10 @@
                 this.velocity = new Phaser.Math.Vector2(0, 0);
                 this.isBoosting = false;
                 this.isFiring = false;
-                this.maxFuel = 200;
+                this.maxFuel = window.baseStats.maxFuel;
                 this.fuel = this.maxFuel;
-                this.ammo = 50;
+                this.ammo = window.baseStats.ammo;
+                this.boostThrust = window.baseStats.boostThrust;
                 this.credits = 0;
                 this.fireRate = 100;
                 this.lastFired = 0;
@@ -394,7 +419,7 @@
                 }
 
                 if (this.isBoosting && this.fuel > 0) {
-                    const accel = 200;
+                    const accel = this.boostThrust;
                     this.velocity.x += Math.cos(noseAngle) * accel * deltaSeconds;
                     this.velocity.y += Math.sin(noseAngle) * accel * deltaSeconds;
                     this.fuel -= 12 * deltaSeconds;


### PR DESCRIPTION
## Summary
- display starting ship stats in new inventory panel
- style inventory panel
- compute and update panel values in main.js
- update purchase logic to refresh inventory
- test inventory panel behavior

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68546989e47c832b89ac360d278f04f6