### PR TITLE
Adjust power-up visuals and legend icons

### DIFF
--- a/features/powerup_pickup.feature
+++ b/features/powerup_pickup.feature
@@ -11,7 +11,7 @@ Feature: Power-up pickups
     When I click the start screen
     Then the game should appear after a short delay
     When I spawn an ammo power-up offset by 100 0 from the ship
-    When I wait for 7000 ms
+    When I wait for 9000 ms
     Then a power-up should be visible
-    When I wait for 3000 ms
+    When I wait for 4000 ms
     Then no power-ups should be visible

--- a/features/start_game.feature
+++ b/features/start_game.feature
@@ -29,3 +29,9 @@ Feature: Start the game
     When I click the start screen
     Then the game should appear after a short delay
     And the legend should be visible
+
+  Scenario: Legend icons match power-up graphics
+    Given I open the game page
+    When I click the start screen
+    Then the game should appear after a short delay
+    And the legend icons should match power-up graphics

--- a/features/step_definitions/steps.js
+++ b/features/step_definitions/steps.js
@@ -264,6 +264,27 @@ Then('menu music should be playing', async () => {
     }
   });
 
+  Then('the legend icons should match power-up graphics', async () => {
+    const icons = await page.$$eval('#legend .legend-dot', els =>
+      els.map(el => ({
+        base: getComputedStyle(el).backgroundColor,
+        lid: getComputedStyle(el, '::after').backgroundColor
+      }))
+    );
+    const expected = [
+      'rgb(255, 255, 0)',
+      'rgb(255, 165, 0)',
+      'rgb(0, 255, 0)'
+    ];
+    const baseColor = 'rgb(139, 69, 19)';
+    if (
+      icons.length !== 3 ||
+      icons.some((ic, i) => ic.base !== baseColor || ic.lid !== expected[i])
+    ) {
+      throw new Error('Legend icons do not match power-up graphics');
+    }
+  });
+
   Then('the legend should not be visible', async () => {
     const display = await page.$eval('#legend', el => getComputedStyle(el).display);
     if (display !== 'none') {
@@ -306,8 +327,8 @@ Then('menu music should be playing', async () => {
       const gs = window.gameScene;
       const time = gs.time.now;
       const chest = gs.add.container(gs.ship.x, gs.ship.y);
-      const base = gs.add.rectangle(0, 3, 20, 11, 0x8b4513);
-      const lid = gs.add.rectangle(0, -4, 20, 6, 0xffff00);
+      const base = gs.add.rectangle(0, 4, 24, 13, 0x8b4513);
+      const lid = gs.add.rectangle(0, -5, 24, 7, 0xffff00);
       chest.add([base, lid]);
       gs.powerUps.push({ sprite: chest, type: 'ammo', spawnTime: time });
       gs.nextPowerUpSpawn = Infinity;
@@ -321,8 +342,8 @@ Then('menu music should be playing', async () => {
       const gs = window.gameScene;
       const time = gs.time.now;
       const chest = gs.add.container(gs.ship.x + dx, gs.ship.y + dy);
-      const base = gs.add.rectangle(0, 3, 20, 11, 0x8b4513);
-      const lid = gs.add.rectangle(0, -4, 20, 6, 0xffff00);
+      const base = gs.add.rectangle(0, 4, 24, 13, 0x8b4513);
+      const lid = gs.add.rectangle(0, -5, 24, 7, 0xffff00);
       chest.add([base, lid]);
       gs.powerUps.push({ sprite: chest, type: 'ammo', spawnTime: time });
       gs.nextPowerUpSpawn = Infinity;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -247,13 +247,27 @@ body.urgent {
 }
 
 .legend-dot {
+    position: relative;
     display: inline-block;
-    width: 10px;
-    height: 10px;
-    border-radius: 50%;
+    width: 14px;
+    height: 12px;
     margin-right: 4px;
+    background: #8b4513;
+    border-radius: 2px;
 }
 
-.legend-dot.ammo { background: #ffff00; }
-.legend-dot.fuel { background: #ffa500; }
-.legend-dot.time { background: #00ff00; }
+.legend-dot::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 4px;
+    border-top-left-radius: 2px;
+    border-top-right-radius: 2px;
+    background: var(--lid-color);
+}
+
+.legend-dot.ammo { --lid-color: #ffff00; }
+.legend-dot.fuel  { --lid-color: #ffa500; }
+.legend-dot.time  { --lid-color: #00ff00; }

--- a/static/lib/main.js
+++ b/static/lib/main.js
@@ -179,7 +179,7 @@
                 this.floatingTexts = [];
                 this.nextPowerUpSpawn = 5000;
                 this.powerUpSpawnRate = 8000; // milliseconds
-                this.powerUpFadeDuration = 9000;
+                this.powerUpFadeDuration = 12000;
                 this.urgentStarted = false;
                 this.urgentInterval = null;
 
@@ -481,8 +481,8 @@
                     if (type === 'fuel') color = 0xffa500;
                     if (type === 'time') color = 0x00ff00;
                     const chest = this.add.container(x, y);
-                    const base = this.add.rectangle(0, 3, 20, 11, 0x8b4513);
-                    const lid = this.add.rectangle(0, -4, 20, 6, color);
+                    const base = this.add.rectangle(0, 4, 24, 13, 0x8b4513);
+                    const lid = this.add.rectangle(0, -5, 24, 7, color);
                     chest.add([base, lid]);
                     chest.setAlpha(1);
                     this.powerUps.push({ sprite: chest, type: type, spawnTime: time });


### PR DESCRIPTION
## Summary
- make power-up chests larger and linger longer
- update CSS so legend icons use chest-style graphics
- update BDD scenario timings for lingering power-ups
- add scenario ensuring legend icons match power-up graphics

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6854692dd21c832b87563f740819313a