### PR TITLE
Add reset progress button

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ loads this file rather than using a CDN.
 - Orb drift & bounce once grown, making them move and ricochet off screen edges.
 - Collision consequences: red orbs add score and streak, blue orbs subtract score, and crashing into any orb ends the game.
 - Destroying a red orb awards 1 credit to spend in the shop.
+- Quick Reset button in the shop footer clears saved progress.
 
 This project is automatically deployed to **GitHub Pages** whenever changes are merged to the `main` branch. The deployment workflow lives at `.github/workflows/deploy.yml` and publishes the root directory to the `gh-pages` branch using the `peaceiris/actions-gh-pages` GitHub Action.
 

--- a/features/reset_progress.feature
+++ b/features/reset_progress.feature
@@ -1,0 +1,15 @@
+Feature: Reset progress
+  Scenario: Reset button clears saved data
+    Given I open the game page
+    And I have 10 credits
+    And the high score is 20
+    When I open the shop tab
+    And I buy the upgrade "Increase Max Ammo"
+    And I click the reset button
+    When I reload the page
+    And I click the start screen
+    Then the game should appear after a short delay
+    And my ammo should be 50
+    And the displayed credits should be 0
+    And the high score should be 0
+    And no permanent upgrades should be stored

--- a/features/step_definitions/steps.js
+++ b/features/step_definitions/steps.js
@@ -620,3 +620,30 @@ Then('the inventory stat icon for {string} should be {string}', async (label, ex
     throw new Error(`Expected icon ${expected} but got ${actual}`);
   }
 });
+
+Given('the high score is {int}', async val => {
+  await page.evaluate(score => {
+    localStorage.setItem('highscore', score);
+    document.getElementById('highscore-value').textContent = score;
+  }, val);
+});
+
+When('I click the reset button', async () => {
+  await page.click('#reset-progress');
+});
+
+Then('the displayed credits should be {int}', async expected => {
+  const val = await page.$eval('#start-credits-value', el => parseInt(el.textContent));
+  if (val !== expected) {
+    throw new Error(`Expected credits ${expected} but got ${val}`);
+  }
+});
+
+Then('no permanent upgrades should be stored', async () => {
+  const count = await page.evaluate(() => {
+    return JSON.parse(localStorage.getItem('permanentUpgrades') || '[]').length;
+  });
+  if (count !== 0) {
+    throw new Error('Permanent upgrades not cleared');
+  }
+});

--- a/index.html
+++ b/index.html
@@ -26,7 +26,10 @@
             <h2>Shop</h2>
             <div id="shop-items"></div>
             <div id="shop-credits">Credits: <span class="total-credits">0</span></div>
-            <button id="close-shop">Close</button>
+            <div id="shop-footer">
+                <button id="reset-progress" class="reset-btn" title="Reset all progress">🔄</button>
+                <button id="close-shop">Close</button>
+            </div>
         </div>
         <div id="inventory-panel">
             <h2>Ship Stats</h2>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -58,6 +58,29 @@ body, html {
     width: 320px;
 }
 
+#shop-footer {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 10px;
+}
+
+.reset-btn {
+    background: #f44336;
+    border: none;
+    color: #fff;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    font-size: 20px;
+    cursor: pointer;
+    box-shadow: 0 0 5px #f44336;
+    transition: box-shadow 0.2s;
+}
+
+.reset-btn:hover {
+    box-shadow: 0 0 10px #fff;
+}
+
 #inventory-panel {
     position: absolute;
     top: 20px;

--- a/static/lib/main.js
+++ b/static/lib/main.js
@@ -128,6 +128,22 @@
             }
         }
 
+        function resetProgress() {
+            localStorage.removeItem('highscore');
+            localStorage.removeItem('credits');
+            localStorage.removeItem('permanentUpgrades');
+            sessionStorage.removeItem('sessionUpgrades');
+            window.totalCredits = 0;
+            window.permanentUpgrades = [];
+            window.sessionUpgrades = [];
+            document.querySelectorAll('.total-credits, #start-credits-value').forEach(el => {
+                el.textContent = 0;
+            });
+            document.getElementById('highscore-value').textContent = 0;
+            updateInventoryPanel();
+            renderShop();
+        }
+
         const gameOverBox = document.getElementById('game-over');
         function showGameOver(msg) {
             const finalScore = window.gameScene?.score || 0;
@@ -683,6 +699,7 @@
             renderShop();
             document.getElementById('shop-panel').style.display = 'block';
         });
+        document.getElementById('reset-progress').addEventListener('click', resetProgress);
         document.getElementById('close-shop').addEventListener('click', () => {
             document.getElementById('shop-panel').style.display = 'none';
         });


### PR DESCRIPTION
## Summary
- add prominent reset icon in shop footer
- style reset button
- implement reset logic and events
- support setting high score and resetting via new steps
- test reset functionality end-to-end
- document reset button in README

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68546e4b584c832ba7fdcd5c993bdaaa