### PR TITLE
Fix shop buttons starting game

### DIFF
--- a/features/shop.feature
+++ b/features/shop.feature
@@ -8,3 +8,11 @@ Feature: Shop access
     Given I open the game page
     When I open the shop tab
     Then each upgrade should appear as a card
+
+  Scenario: Buying an upgrade does not start the game
+    Given I open the game page
+    And I have 10 credits
+    When I open the shop tab
+    And I click buy on the upgrade "Increase Max Ammo"
+    Then the game should not be visible
+    And the displayed credits should be 5

--- a/features/step_definitions/steps.js
+++ b/features/step_definitions/steps.js
@@ -559,6 +559,13 @@ When('I buy the upgrade {string}', async name => {
   }, name);
 });
 
+When('I click buy on the upgrade {string}', async name => {
+  await page.$$eval('#shop-panel .shop-item', (items, n) => {
+    const el = items.find(i => i.querySelector('.name').textContent.trim() === n);
+    el.querySelector('.buy-btn').click();
+  }, name);
+});
+
 Then('my ammo should be {int}', async expected => {
   await page.waitForFunction(() => window.gameScene);
   const val = await page.evaluate(() => window.gameScene.ammo);
@@ -636,6 +643,13 @@ Then('the displayed credits should be {int}', async expected => {
   const val = await page.$eval('#start-credits-value', el => parseInt(el.textContent));
   if (val !== expected) {
     throw new Error(`Expected credits ${expected} but got ${val}`);
+  }
+});
+
+Then('the game should not be visible', async () => {
+  const display = await page.$eval('#game', el => getComputedStyle(el).display);
+  if (display !== 'none') {
+    throw new Error('Game should not be visible');
   }
 });
 

--- a/static/lib/main.js
+++ b/static/lib/main.js
@@ -703,6 +703,9 @@
         document.getElementById('close-shop').addEventListener('click', () => {
             document.getElementById('shop-panel').style.display = 'none';
         });
+        document.getElementById('shop-panel').addEventListener('click', e => {
+            e.stopPropagation();
+        });
 
         document.getElementById('start-screen').addEventListener('click', function(e) {
             if (e.target.id === 'shop-tab' || e.target.closest('#shop-panel')) {


### PR DESCRIPTION
## Summary
- prevent clicks inside shop from starting the game
- add step definitions for clicking buy buttons
- test that buying upgrades doesn't start the game

## Testing
- `npm run check`
- `npm test` *(fails: ERR_IPC_CHANNEL_CLOSED)*

------
https://chatgpt.com/codex/tasks/task_e_685471ea1b38832ba722b40b450acef7