### PR TITLE
Implement upgrade preview highlighting

### DIFF
--- a/features/step_definitions/steps.js
+++ b/features/step_definitions/steps.js
@@ -661,3 +661,38 @@ Then('no permanent upgrades should be stored', async () => {
     throw new Error('Permanent upgrades not cleared');
   }
 });
+
+When('I hover over the upgrade {string}', async name => {
+  await page.$$eval('#shop-panel .shop-item', (items, n) => {
+    const el = items.find(i => i.querySelector('.name').textContent.trim() === n);
+    if (el) el.dispatchEvent(new Event('mouseenter', { bubbles: true }));
+  }, name);
+});
+
+When('I stop hovering', async () => {
+  await page.$$eval('#shop-panel .shop-item', items => {
+    items.forEach(el => el.dispatchEvent(new Event('mouseleave', { bubbles: true })));
+  });
+});
+
+Then('the inventory stat {string} should preview {string}', async (label, expected) => {
+  const actual = await page.evaluate(lbl => {
+    const items = Array.from(document.querySelectorAll('#inventory-panel li'));
+    const el = items.find(i => i.textContent.trim().toLowerCase().startsWith(lbl.toLowerCase()));
+    return el ? el.querySelector('span').textContent.trim() : null;
+  }, label);
+  if (actual !== expected) {
+    throw new Error(`Expected preview ${expected} but got ${actual}`);
+  }
+});
+
+Then('the inventory stat {string} should be highlighted', async label => {
+  const highlighted = await page.evaluate(lbl => {
+    const items = Array.from(document.querySelectorAll('#inventory-panel li'));
+    const el = items.find(i => i.textContent.trim().toLowerCase().startsWith(lbl.toLowerCase()));
+    return el ? el.classList.contains('highlight') : false;
+  }, label);
+  if (!highlighted) {
+    throw new Error('Stat not highlighted');
+  }
+});

--- a/features/upgrade_preview.feature
+++ b/features/upgrade_preview.feature
@@ -1,0 +1,10 @@
+Feature: Upgrade preview
+  Scenario: Hovering an upgrade shows stat changes
+    Given I open the game page
+    And I have 10 credits
+    When I open the shop tab
+    And I hover over the upgrade "Extra Starting Fuel"
+    Then the inventory stat "Fuel Capacity" should preview "200 → 250"
+    And the inventory stat "Fuel Capacity" should be highlighted
+    When I stop hovering
+    Then the inventory stat "Fuel Capacity" should be "200"

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -109,6 +109,12 @@ body, html {
     margin-bottom: 4px;
 }
 
+#inventory-panel li.highlight {
+    background: rgba(255, 255, 255, 0.2);
+    border-radius: 4px;
+    padding: 2px 4px;
+}
+
 #inventory-panel li::before {
     margin-right: 4px;
 }

--- a/static/lib/main.js
+++ b/static/lib/main.js
@@ -18,7 +18,7 @@
             shieldDuration: 0
         };
 
-        function updateInventoryPanel() {
+        function getCurrentStats() {
             let fuel = window.baseStats.maxFuel;
             let ammo = window.baseStats.ammo;
             let thrust = window.baseStats.boostThrust;
@@ -26,10 +26,45 @@
             const active = new Set([...window.permanentUpgrades, ...window.sessionUpgrades]);
             if (active.has('extra_fuel')) fuel += 50;
             if (active.has('max_ammo')) ammo = 100;
-            document.getElementById('inv-fuel').textContent = fuel;
-            document.getElementById('inv-ammo').textContent = ammo;
-            document.getElementById('inv-thrust').textContent = thrust;
-            document.getElementById('inv-shield').textContent = shield;
+            return { fuel, ammo, thrust, shield };
+        }
+
+        function updateInventoryPanel(stats = getCurrentStats()) {
+            document.getElementById('inv-fuel').textContent = stats.fuel;
+            document.getElementById('inv-ammo').textContent = stats.ammo;
+            document.getElementById('inv-thrust').textContent = stats.thrust;
+            document.getElementById('inv-shield').textContent = stats.shield;
+        }
+
+        function clearPreview() {
+            document.querySelectorAll('#inventory-panel li').forEach(li => li.classList.remove('highlight'));
+            updateInventoryPanel();
+        }
+
+        function previewUpgrade(item) {
+            clearPreview();
+            const current = getCurrentStats();
+            const preview = { ...current };
+            let statKey;
+            if (item.id === 'extra_fuel') {
+                statKey = 'fuel';
+                preview.fuel += 50;
+            } else if (item.id === 'max_ammo') {
+                statKey = 'ammo';
+                preview.ammo = 100;
+            } else if (item.id === 'shield') {
+                statKey = 'shield';
+                preview.shield = 1;
+            } else {
+                return;
+            }
+            updateInventoryPanel(preview);
+            const li = document.querySelector(`#inventory-panel li.${statKey}`);
+            if (li) {
+                li.classList.add('highlight');
+                const span = li.querySelector('span');
+                span.textContent = `${current[statKey]} → ${preview[statKey]}`;
+            }
         }
 
         updateInventoryPanel();
@@ -97,6 +132,11 @@
                 btn.className = 'buy-btn';
                 btn.textContent = 'Buy';
                 btn.onclick = () => purchase(item);
+
+                div.onmouseenter = () => previewUpgrade(item);
+                div.onmouseleave = () => clearPreview();
+                btn.onfocus = () => previewUpgrade(item);
+                btn.onblur = () => clearPreview();
 
                 div.appendChild(icon);
                 div.appendChild(info);


### PR DESCRIPTION
## Summary
- add upgrade preview feature tests
- preview upgrade effects in inventory panel
- highlight affected stat on hover or focus
- style highlight row in inventory panel

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6854e0919270832bac021c0126584f87