### PR TITLE
Add urgency overlay with progressive red tint

### DIFF
--- a/features/step_definitions/steps.js
+++ b/features/step_definitions/steps.js
@@ -63,14 +63,19 @@ When('I force the timer below ten seconds', async () => {
     if (window.gameScene) {
       window.gameScene.timeRemaining = 9;
     } else {
-      document.body.classList.add('urgent');
+      const ov = document.getElementById('urgency-overlay');
+      if (ov) ov.style.opacity = '0.07';
     }
   });
   await page.waitForTimeout(1000);
 });
 
-Then('the screen should pulse red', async () => {
-  await page.waitForSelector('body.urgent');
+Then('the screen should tint red', async () => {
+  await page.waitForFunction(() => {
+    const ov = document.getElementById('urgency-overlay');
+    if (!ov) return false;
+    return parseFloat(getComputedStyle(ov).opacity) > 0;
+  });
 });
 
 When('I hold the right mouse button for {int} ms', async ms => {

--- a/features/urgent_countdown.feature
+++ b/features/urgent_countdown.feature
@@ -4,4 +4,4 @@ Feature: Urgent countdown display
     When I click the start screen
     And the game should appear after a short delay
     And I force the timer below ten seconds
-    Then the screen should pulse red
+    Then the screen should tint red

--- a/index.html
+++ b/index.html
@@ -46,6 +46,7 @@
         <img src="static/images/promo_animated.webp" alt="Promo Animation">
     </div>
     <div id="game"></div>
+    <div id="urgency-overlay"></div>
     <div id="fuel-container"><div id="fuel-bar"></div></div>
     <div id="ammo-container">Ammo: <span id="ammo-count">0</span></div>
     <div id="credits-container">Credits: <span id="credits">0</span></div>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -256,13 +256,16 @@ body, html {
     font-family: Arial, sans-serif;
     display: none;
 }
-@keyframes pulseRed {
-    0% { background-color: rgba(255, 0, 0, 0.2); }
-    50% { background-color: rgba(255, 0, 0, 0.5); }
-    100% { background-color: rgba(255, 0, 0, 0.2); }
-}
-body.urgent {
-    animation: pulseRed 1s infinite;
+#urgency-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    background-color: red;
+    opacity: 0;
+    transition: opacity 0.2s linear;
 }
 
 #level-banner {

--- a/static/lib/main.js
+++ b/static/lib/main.js
@@ -223,6 +223,7 @@
                 this.powerUpFadeDuration = 12000;
                 this.urgentStarted = false;
                 this.urgentInterval = null;
+                this.urgencyOverlay = document.getElementById('urgency-overlay');
 
                 // Orb management
                 this.orbs = [];
@@ -405,7 +406,7 @@
                 this.timeRemaining -= deltaSeconds;
                 if (this.timeRemaining <= 0) {
                     clearInterval(this.urgentInterval);
-                    document.body.classList.remove('urgent');
+                    if (this.urgencyOverlay) this.urgencyOverlay.style.opacity = '0';
                     sfx.timeout.currentTime = 0;
                     sfx.timeout.play().catch(() => {});
                     window.currentGameplayMusic?.pause();
@@ -415,10 +416,19 @@
                     this.gameOver = true;
                     return;
                 }
-                if (this.timeRemaining <= 10 && !this.urgentStarted) {
-                    document.body.classList.add('urgent');
-                    this.urgentStarted = true;
-                    this.urgentInterval = setInterval(playTick, 2000);
+                if (this.timeRemaining <= 10) {
+                    if (!this.urgentStarted) {
+                        this.urgentStarted = true;
+                        this.urgentInterval = setInterval(playTick, 2000);
+                    }
+                    const intensity = 1 - Math.max(0, this.timeRemaining) / 10;
+                    if (this.urgencyOverlay) {
+                        this.urgencyOverlay.style.opacity = (intensity * 0.7).toFixed(2);
+                    }
+                } else if (this.urgentStarted) {
+                    this.urgentStarted = false;
+                    clearInterval(this.urgentInterval);
+                    if (this.urgencyOverlay) this.urgencyOverlay.style.opacity = '0';
                 }
 
                 if (this.isFiring && this.ammo > 0 && time > this.lastFired + this.fireRate) {
@@ -598,7 +608,7 @@
                             this.orbs.splice(i, 1);
                         } else {
                             clearInterval(this.urgentInterval);
-                            document.body.classList.remove('urgent');
+                            if (this.urgencyOverlay) this.urgencyOverlay.style.opacity = '0';
                             sfx.crash.currentTime = 0;
                             sfx.crash.play().catch(() => {});
                             sfx.explosion.currentTime = 0;
@@ -663,7 +673,7 @@
                             sessionStorage.setItem('sessionUpgrades', JSON.stringify(window.sessionUpgrades));
                         } else {
                             clearInterval(this.urgentInterval);
-                            document.body.classList.remove('urgent');
+                            if (this.urgencyOverlay) this.urgencyOverlay.style.opacity = '0';
                             sfx.crash.currentTime = 0;
                             sfx.crash.play().catch(() => {});
                             window.currentGameplayMusic?.pause();


### PR DESCRIPTION
## Summary
- overlay element for time urgency
- gradual red tint as timer counts down
- update BDD test to look for tinted screen

## Testing
- `npm run check`
- `npx cucumber-js --parallel 1` *(fails: orb_gravity scenario)*
- `npx cucumber-js features/urgent_countdown.feature`

------
https://chatgpt.com/codex/tasks/task_e_6854e1d9a678832b862ea6028f7ea284