### PR TITLE
Fix missing visuals from module split

### DIFF
--- a/static/css/components/start-screen.css
+++ b/static/css/components/start-screen.css
@@ -7,7 +7,7 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    background: url('../images/promo.webp') center center / cover no-repeat;
+    background: url('../../images/promo.webp') center center / cover no-repeat;
 }
 #highscore-display {
     position: absolute;

--- a/static/lib/game/scene.js
+++ b/static/lib/game/scene.js
@@ -51,7 +51,8 @@
     this.orbSpeedMultiplier = 1;
 
     this.level = 1;
-    this.levelDuration = levelDurationMs;
+    const duration = window.levelDuration || 15000;
+    this.levelDuration = duration;
     this.startTime = null;
     this.nextLevelTime = null;
     this.levelBanner = document.getElementById('level-banner');


### PR DESCRIPTION
## Summary
- ensure game scene uses global level duration
- correct start screen background path

## Testing
- `npm run check`
- `npm test` *(fails: many scenarios fail)*

------
https://chatgpt.com/codex/tasks/task_e_6854f933c8b4832bbc183fce14f66712