### PR TITLE
Fix missing sound effects global

### DIFF
--- a/static/lib/audio.js
+++ b/static/lib/audio.js
@@ -31,6 +31,7 @@
   }
 
   window.audioElements = { menuMusic, playTracks, sfx };
+  window.sfx = sfx;
   window.playTick = playTick;
 
   menuMusic.play().catch(() => {});


### PR DESCRIPTION
## Summary
- expose `sfx` globally so other modules (like game scene) work

## Testing
- `npm run check`
- `npm test` *(fails: `sfx` not defined` etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685507a69dfc832b88732f2debc5fc1c