### PR TITLE
Fix ship upgrade stat display

### DIFF
--- a/features/inventory_panel.feature
+++ b/features/inventory_panel.feature
@@ -21,6 +21,8 @@ Feature: Inventory panel
     When I open the shop tab
     And I buy the upgrade "Increase Max Ammo"
     And I buy the upgrade "Extra Starting Fuel"
+    And I buy the upgrade "Temporary Shield"
     When I reload the page
     Then the inventory stat "Fuel Capacity" should be "250"
     And the inventory stat "Ammo Limit" should be "100"
+    And the inventory stat "Shield Duration" should be "1"

--- a/features/step_definitions/economy.js
+++ b/features/step_definitions/economy.js
@@ -43,8 +43,8 @@ When('I simulate hitting {int} red orbs', async count => {
 
 When('I buy the upgrade {string}', async name => {
   await ctx.page.evaluate(n => {
-    const item = shopItems.find(i => i.name === n);
-    if (item) purchase(item);
+    const item = window.shop.items.find(i => i.name === n);
+    if (item) window.shop.purchase(item);
   }, name);
 });
 

--- a/static/lib/stats.js
+++ b/static/lib/stats.js
@@ -14,6 +14,7 @@
     const active = new Set([...(window.permanentUpgrades||[]), ...(window.sessionUpgrades||[])]);
     if(active.has('extra_fuel')) fuel += 50;
     if(active.has('max_ammo')) ammo = 100;
+    if(active.has('shield')) shield = 1;
     return {fuel, ammo, thrust, shield};
   }
 


### PR DESCRIPTION
## Summary
- update shop test step to use global `shop` object
- show shield effect in stats
- check shield upgrade in inventory panel scenario

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68550df6889c832ba2572f8c4e53ae08