### PR TITLE
Fix failing upgrade tests

### DIFF
--- a/static/lib/shop.js
+++ b/static/lib/shop.js
@@ -6,6 +6,9 @@
     { id: 'shield', name: 'Temporary Shield', desc: 'Absorb the next hit you take.', icon: '🛡️', cost: 2, stock: 1 }
   ];
 
+  // Expose items for tests and other modules
+  window.shopItems = items;
+
   function renderShop(){
     const container = document.getElementById('shop-items');
     container.innerHTML = '';
@@ -71,4 +74,6 @@
   }
 
   window.shop = { items, renderShop, purchase };
+  // Provide globals for tests
+  window.purchase = purchase;
 })();


### PR DESCRIPTION
## Summary
- expose shop utilities globally so tests can interact with them

## Testing
- `npm run check`
- `npx cucumber-js --name "Permanent upgrade persists across sessions"`
- `npx cucumber-js --name "Session upgrade does not persist after reload"`
- `npx cucumber-js --name "Hovering an upgrade shows stat changes"`
- `npx cucumber-js --name "Timer turns urgent when less than 10 seconds remain"`
- `CUCUMBER_PARALLEL=0 npm test` *(fails: browser.newContext: Target page, context or browser has been closed)*

------
https://chatgpt.com/codex/tasks/task_e_68550e73e248832b9a1843e35516111f