### PR TITLE
Fix shop upgrade preview not resetting

### DIFF
--- a/features/inventory_panel.feature
+++ b/features/inventory_panel.feature
@@ -26,3 +26,11 @@ Feature: Inventory panel
     Then the inventory stat "Fuel Capacity" should be "250"
     And the inventory stat "Ammo Limit" should be "100"
     And the inventory stat "Shield Duration" should be "1"
+
+  Scenario: Stats update immediately after buying while previewing
+    Given I open the game page
+    And I have 10 credits
+    When I open the shop tab
+    And I hover over the upgrade "Extra Starting Fuel"
+    And I click buy on the upgrade "Extra Starting Fuel"
+    Then the inventory stat "Fuel Capacity" should be "250"

--- a/static/lib/shop.js
+++ b/static/lib/shop.js
@@ -70,6 +70,7 @@
       if(item.stock) item.stock -= 1;
       renderShop();
       updateInventoryPanel();
+      clearPreview();
     }
   }
 


### PR DESCRIPTION
## Summary
- clear upgrade preview after purchasing
- add a scenario verifying stats update right after buying

## Testing
- `npm run check`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68551dffca14832ba3eaf3b4aa21a5fb