### PR TITLE
Enable stacking of ship upgrades

### DIFF
--- a/features/inventory_panel.feature
+++ b/features/inventory_panel.feature
@@ -34,3 +34,12 @@ Feature: Inventory panel
     And I hover over the upgrade "Extra Starting Fuel"
     And I click buy on the upgrade "Extra Starting Fuel"
     Then the inventory stat "Fuel Capacity" should be "250"
+
+  Scenario: Upgrades stack with multiple purchases
+    Given I open the game page
+    And I have 15 credits
+    When I open the shop tab
+    And I buy the upgrade "Increase Max Ammo"
+    And I buy the upgrade "Increase Max Ammo"
+    When I reload the page
+    Then the inventory stat "Ammo Limit" should be "150"

--- a/features/step_definitions/world.js
+++ b/features/step_definitions/world.js
@@ -194,6 +194,8 @@ Then('no orbs should be visible', async () => {
   const count = await ctx.page.evaluate(() => window.gameScene.orbs.length);
   if (count !== 0) {
     throw new Error('Orb still visible');
+  }
+});
 
 When('I place the ship at {int} {int} with velocity {int} {int}', async (x, y, vx, vy) => {
   await ctx.page.waitForFunction(() => window.gameScene && window.gameScene.ship);

--- a/static/lib/game/scene.js
+++ b/static/lib/game/scene.js
@@ -19,18 +19,15 @@
     this.bullets = [];
     this.gameOver = false;
 
-    const active = new Set([...window.permanentUpgrades, ...window.sessionUpgrades]);
-    this.shield = active.has('shield');
-    if (active.has('extra_fuel')) {
-        this.maxFuel += 50;
-        this.fuel = this.maxFuel;
-    }
-    if (active.has('fast_reload')) {
-        this.fireRate = 50;
-    }
-    if (active.has('max_ammo')) {
-        this.ammo = 100;
-    }
+    const upgrades = [...window.permanentUpgrades, ...window.sessionUpgrades];
+    this.shield = upgrades.includes('shield');
+    const fuelUps = upgrades.filter(u => u === 'extra_fuel').length;
+    this.maxFuel += fuelUps * 50;
+    this.fuel = this.maxFuel;
+    const reloadUps = upgrades.filter(u => u === 'fast_reload').length;
+    this.fireRate = Math.max(20, this.fireRate - reloadUps * 10);
+    const ammoUps = upgrades.filter(u => u === 'max_ammo').length;
+    this.ammo += ammoUps * 50;
 
     // Timer and power-ups
     this.timeRemaining = 60;

--- a/static/lib/shop.js
+++ b/static/lib/shop.js
@@ -1,7 +1,7 @@
 (function(){
   const items = [
-    { id: 'max_ammo', name: 'Increase Max Ammo', desc: 'Raise your ammo cap to 100.', icon: '🔫', cost: 5, permanent: true },
-    { id: 'extra_fuel', name: 'Extra Starting Fuel', desc: 'Begin with additional fuel reserves.', icon: '⛽', cost: 3 },
+    { id: 'max_ammo', name: 'Increase Max Ammo', desc: 'Add 50 to your ammo limit.', icon: '🔫', cost: 5, permanent: true },
+    { id: 'extra_fuel', name: 'Extra Starting Fuel', desc: 'Add 50 fuel capacity.', icon: '⛽', cost: 3 },
     { id: 'fast_reload', name: 'Faster Reload', desc: 'Reduce time between shots.', icon: '⚡', cost: 4 },
     { id: 'shield', name: 'Temporary Shield', desc: 'Absorb the next hit you take.', icon: '🛡️', cost: 2, stock: 1 }
   ];
@@ -59,10 +59,8 @@
       storage.setCredits(window.totalCredits);
       document.querySelectorAll('.total-credits, #start-credits-value').forEach(el => { el.textContent = window.totalCredits; });
       if(item.permanent){
-        if(!window.permanentUpgrades.includes(item.id)){
-          window.permanentUpgrades.push(item.id);
-          storage.setPermanentUpgrades(window.permanentUpgrades);
-        }
+        window.permanentUpgrades.push(item.id);
+        storage.setPermanentUpgrades(window.permanentUpgrades);
       }else{
         window.sessionUpgrades.push(item.id);
         storage.setSessionUpgrades(window.sessionUpgrades);

--- a/static/lib/stats.js
+++ b/static/lib/stats.js
@@ -11,10 +11,12 @@
     let ammo = baseStats.ammo;
     let thrust = baseStats.boostThrust;
     let shield = baseStats.shieldDuration;
-    const active = new Set([...(window.permanentUpgrades||[]), ...(window.sessionUpgrades||[])]);
-    if(active.has('extra_fuel')) fuel += 50;
-    if(active.has('max_ammo')) ammo = 100;
-    if(active.has('shield')) shield = 1;
+    const active = [...(window.permanentUpgrades || []), ...(window.sessionUpgrades || [])];
+    for (const id of active) {
+      if (id === 'extra_fuel') fuel += 50;
+      else if (id === 'max_ammo') ammo += 50;
+      else if (id === 'shield') shield = 1;
+    }
     return {fuel, ammo, thrust, shield};
   }
 
@@ -40,7 +42,7 @@
       preview.fuel += 50;
     }else if(item.id === 'max_ammo'){
       statKey = 'ammo';
-      preview.ammo = 100;
+      preview.ammo += 50;
     }else if(item.id === 'shield'){
       statKey = 'shield';
       preview.shield = 1;


### PR DESCRIPTION
## Summary
- allow multiple purchases of permanent upgrades
- apply stacked upgrades when computing stats and starting a game
- adjust preview logic for incremental bonuses
- fix truncated step definition and add BDD scenario for stacking upgrades

## Testing
- `npm run check`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685529427c70832bb2c5e86271e8a7de