### PR TITLE
Improve pickup feedback text

### DIFF
--- a/features/powerup_pickup.feature
+++ b/features/powerup_pickup.feature
@@ -5,6 +5,7 @@ Feature: Power-up pickups
     Then the game should appear after a short delay
     When I spawn an ammo power-up on the ship
     Then the ammo should increase by 15
+    And the floating text "+15 Ammo" should appear
 
   Scenario: Power-ups linger before fading
     Given I open the game page

--- a/features/step_definitions/economy.js
+++ b/features/step_definitions/economy.js
@@ -106,6 +106,12 @@ Then('the streak text {string} should appear', async text => {
   }, text);
 });
 
+Then('the floating text {string} should appear', async text => {
+  await ctx.page.waitForFunction(t => {
+    return window.gameScene.floatingTexts.some(ft => ft.sprite.text === t);
+  }, text);
+});
+
 Given('the high score is {int}', async val => {
   await ctx.page.evaluate(score => {
     localStorage.setItem('highscore', score);

--- a/static/lib/game/loop.js
+++ b/static/lib/game/loop.js
@@ -271,10 +271,20 @@
         const dxP = this.ship.x - p.sprite.x;
         const dyP = this.ship.y - p.sprite.y;
         if (dxP * dxP + dyP * dyP <= 28 * 28) {
-            if (p.type === 'ammo') this.ammo += 15;
-            if (p.type === 'fuel') this.fuel = Math.min(this.maxFuel, this.fuel + 25);
-            if (p.type === 'time') this.timeRemaining += 15;
-            const txt = this.add.text(p.sprite.x, p.sprite.y, '+15', { font: '16px Arial', color: '#ffffff' });
+            let label;
+            if (p.type === 'ammo') {
+                this.ammo += 15;
+                label = '+15 Ammo';
+            }
+            if (p.type === 'fuel') {
+                this.fuel = Math.min(this.maxFuel, this.fuel + 25);
+                label = '+25 Fuel';
+            }
+            if (p.type === 'time') {
+                this.timeRemaining += 15;
+                label = '+15 Time';
+            }
+            const txt = this.add.text(p.sprite.x, p.sprite.y, label, { font: '16px Arial', color: '#ffffff' });
             txt.setOrigin(0.5);
             this.floatingTexts.push({ sprite: txt, spawnTime: time });
             sfx.pickup.currentTime = 0;


### PR DESCRIPTION
## Summary
- show item type in pickup floating text
- add generic floating text test step
- check for `+15 Ammo` pickup feedback

## Testing
- `npm run check`
- `npm test` *(fails: ERR_IPC_CHANNEL_CLOSED)*

------
https://chatgpt.com/codex/tasks/task_e_6855315fb600832bba08cc2558f91114