### PR TITLE
Balance late-game power-ups

### DIFF
--- a/features/powerup_pickup.feature
+++ b/features/powerup_pickup.feature
@@ -7,6 +7,15 @@ Feature: Power-up pickups
     Then the ammo should increase by 15
     And the floating text "+15 Ammo" should appear
 
+  Scenario: Ammo power-ups give less ammo at high levels
+    Given I open the game page
+    When I click the start screen
+    Then the game should appear after a short delay
+    When I set the game level to 10
+    When I spawn an ammo power-up on the ship
+    Then the ammo should increase by 8
+    And the floating text "+8 Ammo" should appear
+
   Scenario: Power-ups linger before fading
     Given I open the game page
     When I click the start screen

--- a/features/step_definitions/gameplay.js
+++ b/features/step_definitions/gameplay.js
@@ -48,6 +48,11 @@ Then('the level should be {int}', async expected => {
   }
 });
 
+When('I set the game level to {int}', async lvl => {
+  await ctx.page.waitForFunction(() => window.gameScene);
+  await ctx.page.evaluate(l => { window.gameScene.level = l; }, lvl);
+});
+
 Then('the game should be paused', async () => {
   const paused = await ctx.page.evaluate(() => window.gamePaused);
   if (!paused) {

--- a/features/step_definitions/world.js
+++ b/features/step_definitions/world.js
@@ -76,10 +76,10 @@ When('I spawn an ammo power-up offset by {int} {int} from the ship', async (dx, 
   await ctx.page.waitForTimeout(200);
 });
 
-Then('the ammo should increase by 15', async () => {
+Then('the ammo should increase by {int}', async expected => {
   const ammo = await ctx.page.evaluate(() => window.gameScene.ammo);
-  if (ammo !== ctx.initialAmmo + 15) {
-    throw new Error('Ammo did not increase by 15');
+  if (ammo !== ctx.initialAmmo + expected) {
+    throw new Error(`Ammo did not increase by ${expected}`);
   }
 });
 

--- a/static/lib/game/loop.js
+++ b/static/lib/game/loop.js
@@ -22,6 +22,7 @@
 
     const deltaSeconds = delta / 1000;
     const noseAngle = this.ship.rotation - Math.PI / 2;
+    const powerScale = Math.max(0.5, 1 - (this.level - 1) * 0.05);
 
     // Countdown timer
     this.timeRemaining -= deltaSeconds;
@@ -178,6 +179,7 @@
         this.level += 1;
         this.nextLevelTime += this.levelDuration;
         this.orbSpeedMultiplier *= 1.2;
+        this.powerUpSpawnRate *= 1.05;
         for (const o of this.orbs) {
             o.vx *= 1.2;
             o.vy *= 1.2;
@@ -273,16 +275,19 @@
         if (dxP * dxP + dyP * dyP <= 28 * 28) {
             let label;
             if (p.type === 'ammo') {
-                this.ammo += 15;
-                label = '+15 Ammo';
+                const amt = Math.round(15 * powerScale);
+                this.ammo += amt;
+                label = `+${amt} Ammo`;
             }
             if (p.type === 'fuel') {
-                this.fuel = Math.min(this.maxFuel, this.fuel + 25);
-                label = '+25 Fuel';
+                const amt = Math.round(25 * powerScale);
+                this.fuel = Math.min(this.maxFuel, this.fuel + amt);
+                label = `+${amt} Fuel`;
             }
             if (p.type === 'time') {
-                this.timeRemaining += 15;
-                label = '+15 Time';
+                const amt = Math.round(15 * powerScale);
+                this.timeRemaining += amt;
+                label = `+${amt} Time`;
             }
             const txt = this.add.text(p.sprite.x, p.sprite.y, label, { font: '16px Arial', color: '#ffffff' });
             txt.setOrigin(0.5);


### PR DESCRIPTION
## Summary
- tune power-up amounts based on current level
- slow power-up spawn rate slightly on each level
- allow specifying expected ammo increase in step definitions
- add step to set the game level in tests
- cover high level power-up scaling with a new BDD scenario

## Testing
- `npm run check`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855334f5bc0832b9108d50e4c8a6aa6