### PR TITLE
Add stat dashboard for upgrades

### DIFF
--- a/features/inventory_panel.feature
+++ b/features/inventory_panel.feature
@@ -4,6 +4,7 @@ Feature: Inventory panel
     Then the inventory panel should be visible
     And the inventory stat "Fuel Capacity" should be "200"
     And the inventory stat "Ammo Limit" should be "50"
+    And the inventory stat "Reload Time" should be "100"
     And the inventory stat "Boost Thrust" should be "200"
     And the inventory stat "Shield Duration" should be "0"
 
@@ -12,6 +13,7 @@ Feature: Inventory panel
     Then the inventory panel should be visible
     And the inventory stat icon for "Fuel Capacity" should be "⛽"
     And the inventory stat icon for "Ammo Limit" should be "🔫"
+    And the inventory stat icon for "Reload Time" should be "⚡"
     And the inventory stat icon for "Boost Thrust" should be "🚀"
     And the inventory stat icon for "Shield Duration" should be "🛡️"
 
@@ -43,3 +45,13 @@ Feature: Inventory panel
     And I buy the upgrade "Increase Max Ammo"
     When I reload the page
     Then the inventory stat "Ammo Limit" should be "150"
+
+  Scenario: Credits spent are displayed for each stat
+    Given I open the game page
+    And I have 8 credits
+    When I open the shop tab
+    And I buy the upgrade "Increase Max Ammo"
+    And I buy the upgrade "Extra Starting Fuel"
+    When I reload the page
+    Then the inventory investment for "Ammo Limit" should be "5"
+    And the inventory investment for "Fuel Capacity" should be "3"

--- a/features/step_definitions/inventory.js
+++ b/features/step_definitions/inventory.js
@@ -66,3 +66,14 @@ Then('the inventory stat {string} should be highlighted', async label => {
     throw new Error('Stat not highlighted');
   }
 });
+
+Then('the inventory investment for {string} should be {string}', async (label, expected) => {
+  const actual = await ctx.page.evaluate(lbl => {
+    const items = Array.from(document.querySelectorAll('#inventory-panel li'));
+    const el = items.find(i => i.textContent.trim().toLowerCase().startsWith(lbl.toLowerCase()));
+    return el ? el.querySelector('.invest')?.textContent.trim() : null;
+  }, label);
+  if (actual !== expected) {
+    throw new Error(`Expected investment ${expected} but got ${actual}`);
+  }
+});

--- a/index.html
+++ b/index.html
@@ -40,10 +40,11 @@
         <div id="inventory-panel">
             <h2>Ship Stats</h2>
             <ul>
-                <li class="fuel">Fuel Capacity: <span id="inv-fuel">0</span></li>
-                <li class="ammo">Ammo Limit: <span id="inv-ammo">0</span></li>
-                <li class="thrust">Boost Thrust: <span id="inv-thrust">0</span></li>
-                <li class="shield">Shield Duration: <span id="inv-shield">0</span></li>
+                <li class="fuel">Fuel Capacity: <span id="inv-fuel">0</span> (<span class="invest" id="inv-fuel-invested">0</span>)</li>
+                <li class="ammo">Ammo Limit: <span id="inv-ammo">0</span> (<span class="invest" id="inv-ammo-invested">0</span>)</li>
+                <li class="reload">Reload Time: <span id="inv-reload">0</span> (<span class="invest" id="inv-reload-invested">0</span>)</li>
+                <li class="thrust">Boost Thrust: <span id="inv-thrust">0</span> (<span class="invest" id="inv-thrust-invested">0</span>)</li>
+                <li class="shield">Shield Duration: <span id="inv-shield">0</span> (<span class="invest" id="inv-shield-invested">0</span>)</li>
             </ul>
         </div>
     </div>

--- a/static/css/components/inventory.css
+++ b/static/css/components/inventory.css
@@ -39,3 +39,10 @@
 #inventory-panel li.ammo::before { content: '🔫'; }
 #inventory-panel li.thrust::before { content: '🚀'; }
 #inventory-panel li.shield::before { content: '🛡️'; }
+#inventory-panel li.reload::before { content: '⚡'; }
+
+#inventory-panel li .invest {
+    font-size: 12px;
+    margin-left: 4px;
+    opacity: 0.8;
+}

--- a/static/lib/stats.js
+++ b/static/lib/stats.js
@@ -3,6 +3,7 @@
     maxFuel: 200,
     ammo: 50,
     boostThrust: 200,
+    reloadTime: 100,
     shieldDuration: 0
   };
 
@@ -10,21 +11,47 @@
     let fuel = baseStats.maxFuel;
     let ammo = baseStats.ammo;
     let thrust = baseStats.boostThrust;
+    let reload = baseStats.reloadTime;
     let shield = baseStats.shieldDuration;
     const active = [...(window.permanentUpgrades || []), ...(window.sessionUpgrades || [])];
     for (const id of active) {
       if (id === 'extra_fuel') fuel += 50;
       else if (id === 'max_ammo') ammo += 50;
+      else if (id === 'fast_reload') reload = Math.max(20, reload - 10);
       else if (id === 'shield') shield = 1;
     }
-    return {fuel, ammo, thrust, shield};
+    return {fuel, ammo, thrust, reload, shield};
   }
 
-  function updateInventoryPanel(stats = getCurrentStats()){
+  function getCreditInvestments(){
+    const map = {};
+    if(window.shop?.items){
+      for(const it of window.shop.items){
+        map[it.id] = it.cost;
+      }
+    }
+    const active = [...(window.permanentUpgrades || []), ...(window.sessionUpgrades || [])];
+    const invest = { fuel: 0, ammo: 0, reload: 0, thrust: 0, shield: 0 };
+    for(const id of active){
+      if(id === 'extra_fuel') invest.fuel += map[id] || 0;
+      else if(id === 'max_ammo') invest.ammo += map[id] || 0;
+      else if(id === 'fast_reload') invest.reload += map[id] || 0;
+      else if(id === 'shield') invest.shield += map[id] || 0;
+    }
+    return invest;
+  }
+
+  function updateInventoryPanel(stats = getCurrentStats(), invest = getCreditInvestments()){
     document.getElementById('inv-fuel').textContent = stats.fuel;
+    document.getElementById('inv-fuel-invested').textContent = invest.fuel;
     document.getElementById('inv-ammo').textContent = stats.ammo;
+    document.getElementById('inv-ammo-invested').textContent = invest.ammo;
+    document.getElementById('inv-reload').textContent = stats.reload;
+    document.getElementById('inv-reload-invested').textContent = invest.reload;
     document.getElementById('inv-thrust').textContent = stats.thrust;
+    document.getElementById('inv-thrust-invested').textContent = invest.thrust;
     document.getElementById('inv-shield').textContent = stats.shield;
+    document.getElementById('inv-shield-invested').textContent = invest.shield;
   }
 
   function clearPreview(){


### PR DESCRIPTION
## Summary
- add credit investment display to start-screen stat panel
- style new stat investment elements
- track credits spent on upgrades and reload time in stats module
- verify investments and reload time through BDD tests

## Testing
- `npm run check`
- `npm test` *(fails: Error [ERR_IPC_CHANNEL_CLOSED])*

------
https://chatgpt.com/codex/tasks/task_e_6855335d6720832b94c43a57c76ba53f