### PR TITLE
Implement docking pause mechanic

### DIFF
--- a/features/step_definitions/gameplay.js
+++ b/features/step_definitions/gameplay.js
@@ -60,6 +60,13 @@ Then('the game should be paused', async () => {
   }
 });
 
+Then('the game should not be paused', async () => {
+  const paused = await ctx.page.evaluate(() => window.gamePaused);
+  if (paused) {
+    throw new Error('Game unexpectedly paused');
+  }
+});
+
 Then('the time remaining should be {int}', async expected => {
   const val = await ctx.page.evaluate(() => Math.ceil(window.gameScene.timeRemaining));
   if (val !== expected) {
@@ -78,6 +85,15 @@ Then('the ship should have moved', async () => {
   const dist = Math.hypot(pos.x - ctx.lastShipPos.x, pos.y - ctx.lastShipPos.y);
   if (dist < 5) {
     throw new Error('Ship did not move');
+  }
+});
+
+Then('the ship should not have moved', async () => {
+  await ctx.page.waitForFunction(() => window.gameScene);
+  const pos = await ctx.page.evaluate(() => ({ x: window.gameScene.ship.x, y: window.gameScene.ship.y }));
+  const dist = Math.hypot(pos.x - ctx.lastShipPos.x, pos.y - ctx.lastShipPos.y);
+  if (dist > 2) {
+    throw new Error('Ship moved unexpectedly');
   }
 });
 

--- a/features/step_definitions/world.js
+++ b/features/step_definitions/world.js
@@ -262,3 +262,21 @@ Then('the trader ship should have moved', async () => {
     throw new Error('Trader ship did not move');
   }
 });
+
+Then('the docking banner should be visible', async () => {
+  const display = await ctx.page.$eval('#dock-banner', el => getComputedStyle(el).display);
+  if (display === 'none') {
+    throw new Error('Dock banner not visible');
+  }
+});
+
+Then('the docking banner should not be visible', async () => {
+  const display = await ctx.page.$eval('#dock-banner', el => getComputedStyle(el).display);
+  if (display !== 'none') {
+    throw new Error('Dock banner should be hidden');
+  }
+});
+
+When('I click the undock button', async () => {
+  await ctx.page.click('#undock-btn');
+});

--- a/features/trader_ship.feature
+++ b/features/trader_ship.feature
@@ -9,7 +9,7 @@ Feature: Trader ship sightings
     And I wait for 400 ms
     Then the trader ship should have moved
 
-  Scenario: Colliding with the trader ship pushes the player
+  Scenario: Colliding with the trader ship does not push the player
     Given I open the game page
     And the trader spawn interval is 1000 ms
     When I click the start screen
@@ -18,4 +18,18 @@ Feature: Trader ship sightings
     And I record the ship position
     And I spawn the trader ship on the ship
     And I wait for 100 ms
-    Then the ship should have moved
+    Then the ship should not have moved
+
+  Scenario: Docking pauses the game
+    Given I open the game page
+    And the trader spawn interval is 100 ms
+    When I click the start screen
+    Then the game should appear after a short delay
+    When I place the ship at 300 300 with velocity 0 0
+    And I spawn the trader ship on the ship
+    And I wait for 2100 ms
+    Then the docking banner should be visible
+    And the game should be paused
+    When I click the undock button
+    Then the docking banner should not be visible
+    And the game should not be paused

--- a/index.html
+++ b/index.html
@@ -48,6 +48,7 @@
     <div id="credits-container">Credits: <span id="credits">0</span></div>
     <div id="score-container">Score: <span id="score">0</span> | Streak: <span id="streak">0</span> | Time: <span id="time-remaining">60</span></div>
     <div id="level-banner"></div>
+    <div id="dock-banner">Docked at Trading Vessel<br><button id="undock-btn">Undock</button></div>
     <div id="legend">
         <div><span class="legend-dot ammo" data-shape="cross"></span> Ammo</div>
         <div><span class="legend-dot fuel" data-shape="triangle"></span> Fuel</div>

--- a/static/css/components/overlays.css
+++ b/static/css/components/overlays.css
@@ -39,6 +39,26 @@
     transition: opacity 1s;
 }
 
+#dock-banner {
+    position: absolute;
+    top: 40%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: rgba(0, 0, 0, 0.7);
+    border: 2px solid #fff;
+    padding: 20px;
+    color: #fff;
+    font-family: Arial, sans-serif;
+    text-align: center;
+    display: none;
+    z-index: 10;
+}
+
+#dock-banner button {
+    margin-top: 10px;
+    padding: 4px 12px;
+}
+
 #game-over {
     position: absolute;
     top: 0;

--- a/static/lib/boot.js
+++ b/static/lib/boot.js
@@ -2,6 +2,24 @@
   const { menuMusic, playTracks, sfx } = window.audioElements;
   window.gamePaused = false;
 
+  function pauseGame(){
+    window.currentGameplayMusic?.pause();
+    sfx.boost.pause();
+    sfx.boost.currentTime = 0;
+    if(window.gameScene){
+      window.gameScene.scene.pause();
+      window.gamePaused = true;
+    }
+  }
+
+  function resumeGame(){
+    if(window.gameScene){
+      window.gameScene.scene.resume();
+      window.gamePaused = false;
+    }
+    window.currentGameplayMusic?.play().catch(()=>{});
+  }
+
   const storedHigh = storage.getHighscore();
   document.getElementById('highscore-value').textContent = storedHigh;
   window.totalCredits = storage.getCredits();
@@ -82,22 +100,11 @@
   function handleVisibility(){
     if(document.hidden){
       menuMusic.pause();
-      window.currentGameplayMusic?.pause();
-      sfx.boost.pause();
-      sfx.boost.currentTime = 0;
-      if(window.gameScene){
-        window.gameScene.scene.pause();
-        window.gamePaused = true;
-      }
+      pauseGame();
     }else{
-      if(window.gameScene){
-        window.gameScene.scene.resume();
-        window.gamePaused = false;
-      }
+      resumeGame();
       if(document.getElementById('start-screen').style.display !== 'none'){
         menuMusic.play().catch(()=>{});
-      }else if(window.currentGameplayMusic){
-        window.currentGameplayMusic.play().catch(()=>{});
       }
     }
   }
@@ -107,4 +114,6 @@
   window.resetProgress = resetProgress;
   window.startGame = startGame;
   window.showGameOver = showGameOver;
+  window.pauseGame = pauseGame;
+  window.resumeGame = resumeGame;
 })();

--- a/static/lib/game/loop.js
+++ b/static/lib/game/loop.js
@@ -317,10 +317,34 @@
         this.spawnTraderShip(x, y, dir);
     }
     if (this.traderShip) {
+        if (this.dockingStart || this.isDocked) {
+            this.traderShip.speed = 0;
+        } else {
+            this.traderShip.speed = this.traderShip.baseSpeed;
+        }
         this.traderShip.x += this.traderShip.speed * deltaSeconds * this.traderShip.dir;
         const dx = this.ship.x - this.traderShip.x;
         const dy = this.ship.y - this.traderShip.y;
-        if (dx * dx + dy * dy < 50 * 50) {
+        const distSq = dx * dx + dy * dy;
+        const dockRange = 40 * 40;
+        if (!this.isDocked && distSq <= dockRange) {
+            if (!this.dockingStart) {
+                this.startDocking(time);
+            } else {
+                const prog = (time - this.dockingStart) / 2000;
+                this.dockRing.clear();
+                this.dockRing.lineStyle(2, 0x00ff00);
+                this.dockRing.beginPath();
+                this.dockRing.arc(this.ship.x, this.ship.y, 30, -Math.PI / 2, -Math.PI / 2 + prog * Math.PI * 2, false);
+                this.dockRing.strokePath();
+                if (prog >= 1) {
+                    this.completeDocking();
+                }
+            }
+        } else if (this.dockingStart) {
+            this.abortDocking();
+        }
+        if (!this.isDocked && !this.dockingStart && distSq < 50 * 50) {
             const angle = Math.atan2(dy, dx);
             const force = 300;
             this.velocity.x += Math.cos(angle) * force;

--- a/static/lib/game/scene.js
+++ b/static/lib/game/scene.js
@@ -205,10 +205,47 @@
         container.add([body, cockpit, flame]);
         this.tweens.add({ targets: flame, scaleX: 1.5, yoyo: true, repeat: -1, duration: 300 });
         container.dir = dir;
-        container.speed = 40;
+        container.baseSpeed = 40;
+        container.speed = container.baseSpeed;
         this.traderShip = container;
     };
     window.spawnTraderShip = (x, y, dir) => this.spawnTraderShip(x, y, dir);
+
+    // Docking helpers
+    this.dockingStart = null;
+    this.dockRing = this.add.graphics();
+    this.dockRing.visible = false;
+    this.dockBanner = document.getElementById('dock-banner');
+    this.undockBtn = document.getElementById('undock-btn');
+    this.isDocked = false;
+
+    this.abortDocking = () => {
+        this.dockRing.clear();
+        this.dockRing.visible = false;
+        this.dockingStart = null;
+    };
+
+    this.startDocking = t => {
+        this.dockingStart = t;
+        this.dockRing.visible = true;
+        this.dockRing.clear();
+    };
+
+    this.completeDocking = () => {
+        this.abortDocking();
+        this.isDocked = true;
+        this.dockBanner.style.display = 'block';
+        window.pauseGame();
+    };
+
+    this.undock = () => {
+        if (!this.isDocked) return;
+        this.isDocked = false;
+        this.dockBanner.style.display = 'none';
+        window.resumeGame();
+    };
+
+    this.undockBtn.addEventListener('click', this.undock);
 
 }
   window.gameCreate = create;


### PR DESCRIPTION
## Summary
- add docking banner and undock button
- style the docking banner overlay
- expose global pauseGame/resumeGame helpers
- implement docking logic for trader ship
- test new docking behaviour

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68553b68cccc832ba2819788ead0c8db