### PR TITLE
Fix reset button behavior

### DIFF
--- a/features/reset_button.feature
+++ b/features/reset_button.feature
@@ -1,0 +1,18 @@
+Feature: Reset button
+  Scenario: Reset button hidden during gameplay
+    Given I open the game page
+    Then the reset button should be visible
+    When I click the start screen
+    Then the game should appear after a short delay
+    And the reset button should not be visible
+
+  Scenario: Reset requires confirmation
+    Given I open the game page
+    And the high score is 50
+    And I have 5 credits
+    When I click the reset button
+    Then the reset warning should be visible
+    When I click the reset button
+    Then the reset warning should not be visible
+    And the displayed credits should be 0
+    And the high score should be 0

--- a/features/step_definitions/reset.js
+++ b/features/step_definitions/reset.js
@@ -1,0 +1,30 @@
+const { Then } = require('@cucumber/cucumber');
+const ctx = require('./context');
+
+Then('the reset button should be visible', async () => {
+  const display = await ctx.page.$eval('#reset-progress', el => getComputedStyle(el).display);
+  if (display === 'none') {
+    throw new Error('Reset button not visible');
+  }
+});
+
+Then('the reset button should not be visible', async () => {
+  const display = await ctx.page.$eval('#reset-progress', el => getComputedStyle(el).display);
+  if (display !== 'none') {
+    throw new Error('Reset button should be hidden');
+  }
+});
+
+Then('the reset warning should be visible', async () => {
+  const display = await ctx.page.$eval('#reset-warning', el => getComputedStyle(el).display);
+  if (display === 'none') {
+    throw new Error('Reset warning not visible');
+  }
+});
+
+Then('the reset warning should not be visible', async () => {
+  const display = await ctx.page.$eval('#reset-warning', el => getComputedStyle(el).display);
+  if (display !== 'none') {
+    throw new Error('Reset warning should be hidden');
+  }
+});

--- a/index.html
+++ b/index.html
@@ -54,6 +54,7 @@
         <div><span class="legend-dot time" data-shape="circle"></span> Time</div>
     </div>
     <button id="reset-progress" class="reset-btn" title="Reset all progress">🗑️</button>
+    <div id="reset-warning" class="reset-warning">Do you really want to reset?</div>
     <script src="static/lib/phaser.min.js"></script>
     <script src="static/lib/audio.js"></script>
     <script src="static/lib/storage.js"></script>

--- a/static/css/components/overlays.css
+++ b/static/css/components/overlays.css
@@ -55,3 +55,18 @@
     text-align: center;
     cursor: pointer;
 }
+
+#reset-warning {
+    position: absolute;
+    bottom: 80px;
+    left: 50%;
+    transform: translateX(-50%);
+    padding: 8px 12px;
+    background: rgba(0, 0, 0, 0.8);
+    color: #fff;
+    font-family: Arial, sans-serif;
+    font-size: 16px;
+    border-radius: 4px;
+    display: none;
+    z-index: 1001;
+}

--- a/static/lib/boot.js
+++ b/static/lib/boot.js
@@ -14,6 +14,10 @@
 
   updateInventoryPanel();
 
+  const resetBtn = document.getElementById('reset-progress');
+  const resetWarning = document.getElementById('reset-warning');
+  let confirmReset = false;
+
   function resetProgress(){
     storage.resetAll();
     window.totalCredits = 0;
@@ -22,6 +26,17 @@
     document.querySelectorAll('.total-credits, #start-credits-value').forEach(el => { el.textContent = 0; });
     document.getElementById('highscore-value').textContent = 0;
     updateInventoryPanel();
+  }
+
+  function handleResetClick(){
+    if(!confirmReset){
+      confirmReset = true;
+      resetWarning.style.display = 'block';
+      return;
+    }
+    resetWarning.style.display = 'none';
+    confirmReset = false;
+    resetProgress();
   }
 
   const gameOverBox = document.getElementById('game-over');
@@ -61,9 +76,12 @@
     });
   }
 
-  document.getElementById('reset-progress').addEventListener('click', resetProgress);
+  resetBtn.addEventListener('click', handleResetClick);
 
   document.getElementById('start-screen').addEventListener('click', function(){
+    resetBtn.style.display = 'none';
+    resetWarning.style.display = 'none';
+    confirmReset = false;
     document.getElementById('start-screen').style.display = 'none';
     const promo = document.getElementById('promo-animation');
     promo.style.display = 'flex';


### PR DESCRIPTION
## Summary
- hide reset button after the game starts
- add a confirmation step before resetting progress
- style reset warning overlay
- add BDD tests for reset button behavior

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68553cfd1fc0832b9c3c7aa830d9b8c7