### PR TITLE
Implement dock shop overlay

### DIFF
--- a/features/shop_overlay.feature
+++ b/features/shop_overlay.feature
@@ -1,0 +1,17 @@
+Feature: Shop overlay
+  Scenario: Viewing shop while docked
+    Given I open the game page
+    And the trader spawn interval is 100 ms
+    When I click the start screen
+    Then the game should appear after a short delay
+    When I place the ship at 300 300 with velocity 0 0
+    And I spawn the trader ship on the ship
+    And I wait for 2100 ms
+    Then the docking banner should be visible
+    And the shop overlay should be visible
+    And the shop credits should be 0
+    And the shop stat "Ammo Limit" should be "50"
+    When I click the undock button
+    Then the shop overlay should not be visible
+    And the docking banner should not be visible
+    And the game should not be paused

--- a/features/step_definitions/shop.js
+++ b/features/step_definitions/shop.js
@@ -1,0 +1,34 @@
+const { Then } = require('@cucumber/cucumber');
+const ctx = require('./context');
+
+Then('the shop overlay should be visible', async () => {
+  const open = await ctx.page.$eval('#shop-overlay', el => el.classList.contains('open'));
+  if (!open) {
+    throw new Error('Shop overlay not visible');
+  }
+});
+
+Then('the shop overlay should not be visible', async () => {
+  const open = await ctx.page.$eval('#shop-overlay', el => el.classList.contains('open'));
+  if (open) {
+    throw new Error('Shop overlay should be hidden');
+  }
+});
+
+Then('the shop credits should be {int}', async expected => {
+  const val = await ctx.page.$eval('#shop-overlay .total-credits', el => parseInt(el.textContent));
+  if (val !== expected) {
+    throw new Error(`Expected credits ${expected} but got ${val}`);
+  }
+});
+
+Then('the shop stat {string} should be {string}', async (label, expected) => {
+  const actual = await ctx.page.evaluate(lbl => {
+    const items = Array.from(document.querySelectorAll('#shop-overlay .stats li'));
+    const el = items.find(i => i.textContent.trim().toLowerCase().startsWith(lbl.toLowerCase()));
+    return el ? el.querySelector('span').textContent.trim() : null;
+  }, label);
+  if (actual !== expected) {
+    throw new Error(`Expected ${label} ${expected} but got ${actual}`);
+  }
+});

--- a/index.html
+++ b/index.html
@@ -49,6 +49,23 @@
     <div id="score-container">Score: <span id="score">0</span> | Streak: <span id="streak">0</span> | Time: <span id="time-remaining">60</span></div>
     <div id="level-banner"></div>
     <div id="dock-banner">Docked at Trading Vessel<br><button id="undock-btn">Undock</button></div>
+    <div id="shop-overlay">
+        <h2>Trading Post</h2>
+        <div>Credits: <span class="total-credits">0</span></div>
+        <div id="shop-stats">
+            <h3>Ship Stats</h3>
+            <ul class="stats">
+                <li class="ammo">Ammo Limit: <span id="shop-ammo">0</span></li>
+                <li class="fuel">Fuel Capacity: <span id="shop-fuel">0</span></li>
+                <li class="thrust">Boost Thrust: <span id="shop-thrust">0</span></li>
+                <li class="reload">Reload Time: <span id="shop-reload">0</span></li>
+            </ul>
+        </div>
+        <h3>Upgrades</h3>
+        <ul id="shop-items">
+            <li>Upgrades coming soon</li>
+        </ul>
+    </div>
     <div id="legend">
         <div><span class="legend-dot ammo" data-shape="cross"></span> Ammo</div>
         <div><span class="legend-dot fuel" data-shape="triangle"></span> Fuel</div>

--- a/static/css/components/overlays.css
+++ b/static/css/components/overlays.css
@@ -59,6 +59,57 @@
     padding: 4px 12px;
 }
 
+#shop-overlay {
+    position: absolute;
+    top: 0;
+    right: -260px;
+    width: 260px;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.8);
+    color: #fff;
+    padding: 20px;
+    box-sizing: border-box;
+    font-family: Arial, sans-serif;
+    transition: right 0.3s;
+    z-index: 11;
+}
+
+#shop-overlay.open {
+    right: 0;
+}
+
+#shop-overlay h2 {
+    margin-top: 0;
+    text-align: center;
+    font-size: 20px;
+}
+
+#shop-overlay h3 {
+    margin-bottom: 6px;
+}
+
+#shop-overlay ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+#shop-overlay li {
+    font-size: 14px;
+    margin-bottom: 4px;
+}
+
+#shop-overlay li.fuel::before { content: '⛽'; margin-right: 4px; }
+#shop-overlay li.ammo::before { content: '🔫'; margin-right: 4px; }
+#shop-overlay li.thrust::before { content: '🚀'; margin-right: 4px; }
+#shop-overlay li.reload::before { content: '⚡'; margin-right: 4px; }
+
+#shop-coming {
+    margin-top: 10px;
+    font-style: italic;
+    text-align: center;
+}
+
 #game-over {
     position: absolute;
     top: 0;

--- a/static/lib/boot.js
+++ b/static/lib/boot.js
@@ -31,6 +31,7 @@
   window.sessionUpgrades = storage.getSessionUpgrades();
 
   updateInventoryPanel();
+  updateShopStatsPanel();
 
   function resetProgress(){
     storage.resetAll();
@@ -40,6 +41,7 @@
     document.querySelectorAll('.total-credits, #start-credits-value').forEach(el => { el.textContent = 0; });
     document.getElementById('highscore-value').textContent = 0;
     updateInventoryPanel();
+    updateShopStatsPanel();
   }
 
   const gameOverBox = document.getElementById('game-over');

--- a/static/lib/game/scene.js
+++ b/static/lib/game/scene.js
@@ -217,6 +217,7 @@
     this.dockRing.visible = false;
     this.dockBanner = document.getElementById('dock-banner');
     this.undockBtn = document.getElementById('undock-btn');
+    this.shopOverlay = document.getElementById('shop-overlay');
     this.isDocked = false;
 
     this.abortDocking = () => {
@@ -235,6 +236,10 @@
         this.abortDocking();
         this.isDocked = true;
         this.dockBanner.style.display = 'block';
+        if(this.shopOverlay){
+            this.shopOverlay.classList.add('open');
+            updateShopStatsPanel();
+        }
         window.pauseGame();
     };
 
@@ -242,6 +247,9 @@
         if (!this.isDocked) return;
         this.isDocked = false;
         this.dockBanner.style.display = 'none';
+        if(this.shopOverlay){
+            this.shopOverlay.classList.remove('open');
+        }
         window.resumeGame();
     };
 

--- a/static/lib/stats.js
+++ b/static/lib/stats.js
@@ -85,9 +85,23 @@
     }
   }
 
+  function updateShopStatsPanel(stats = getCurrentStats()){
+    const map = {
+      fuel: 'shop-fuel',
+      ammo: 'shop-ammo',
+      thrust: 'shop-thrust',
+      reload: 'shop-reload'
+    };
+    for(const key in map){
+      const el = document.getElementById(map[key]);
+      if(el) el.textContent = stats[key];
+    }
+  }
+
   window.baseStats = baseStats;
   window.getCurrentStats = getCurrentStats;
   window.updateInventoryPanel = updateInventoryPanel;
+  window.updateShopStatsPanel = updateShopStatsPanel;
   window.clearPreview = clearPreview;
   window.previewUpgrade = previewUpgrade;
 })();


### PR DESCRIPTION
## Summary
- add a basic shop overlay that slides in when docked
- show credits and stats in the new dock overlay
- update stats module to fill shop panel
- update boot logic for shop stats
- expose overlay controls in game scene
- style the shop overlay
- test that the shop overlay appears while docked

## Testing
- `npm run check`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685540743c90832bbdf5a44c60b04c30