### PR TITLE
Fix docking with trader ship

### DIFF
--- a/features/step_definitions/world.js
+++ b/features/step_definitions/world.js
@@ -242,6 +242,16 @@ When('I spawn the trader ship on the ship', async () => {
   await ctx.page.waitForTimeout(50);
 });
 
+When('I spawn the trader ship at offset {int} {int} from the ship', async (dx, dy) => {
+  await ctx.page.waitForFunction(() => window.gameScene && window.gameScene.spawnTraderShip);
+  await ctx.page.evaluate(({ dx, dy }) => {
+    const gs = window.gameScene;
+    const dir = dx > 0 ? -1 : 1;
+    gs.spawnTraderShip(gs.ship.x + dx, gs.ship.y + dy, dir);
+  }, { dx, dy });
+  await ctx.page.waitForTimeout(50);
+});
+
 When('I record the trader ship position', async () => {
   await ctx.page.waitForFunction(() => window.gameScene?.traderShip);
   ctx.lastTraderPos = await ctx.page.evaluate(() => ({ x: window.gameScene.traderShip.x, y: window.gameScene.traderShip.y }));

--- a/features/trader_ship.feature
+++ b/features/trader_ship.feature
@@ -33,3 +33,14 @@ Feature: Trader ship sightings
     When I click the undock button
     Then the docking banner should not be visible
     And the game should not be paused
+
+  Scenario: Approaching trader ship allows docking
+    Given I open the game page
+    And the trader spawn interval is 100 ms
+    When I click the start screen
+    Then the game should appear after a short delay
+    When I place the ship at 300 300 with velocity 0 0
+    And I spawn the trader ship at offset 45 0 from the ship
+    And I wait for 2100 ms
+    Then the docking banner should be visible
+    And the game should be paused

--- a/static/lib/game/loop.js
+++ b/static/lib/game/loop.js
@@ -344,7 +344,7 @@
         } else if (this.dockingStart) {
             this.abortDocking();
         }
-        if (!this.isDocked && !this.dockingStart && distSq < 50 * 50) {
+        if (!this.isDocked && !this.dockingStart && distSq < 30 * 30) {
             const angle = Math.atan2(dy, dx);
             const force = 300;
             this.velocity.x += Math.cos(angle) * force;


### PR DESCRIPTION
## Summary
- avoid repelling the player when near the trader ship
- add scenario for approaching the trader ship
- spawn trader ship relative to the player's position for tests

## Testing
- `npm run check`
- `npm test` *(fails: Error [ERR_IPC_CHANNEL_CLOSED])*

------
https://chatgpt.com/codex/tasks/task_e_685543096230832b98dd742bf752ca39