### PR TITLE
Implement limited trader inventory

### DIFF
--- a/features/step_definitions/shop.js
+++ b/features/step_definitions/shop.js
@@ -32,3 +32,30 @@ Then('the shop stat {string} should be {string}', async (label, expected) => {
     throw new Error(`Expected ${label} ${expected} but got ${actual}`);
   }
 });
+
+Then('the upgrade {string} should show Sold Out', async name => {
+  const state = await ctx.page.$$eval('#shop-overlay .shop-item', (items, n) => {
+    const el = items.find(i => i.querySelector('.name').textContent.trim() === n);
+    return el ? el.classList.contains('sold-out') && el.querySelector('.buy-btn').textContent.includes('Sold') : false;
+  }, name);
+  if(!state){
+    throw new Error('Sold out state not shown');
+  }
+});
+
+Then('the upgrade {string} should not show Sold Out', async name => {
+  const state = await ctx.page.$$eval('#shop-overlay .shop-item', (items, n) => {
+    const el = items.find(i => i.querySelector('.name').textContent.trim() === n);
+    return el ? el.classList.contains('sold-out') : false;
+  }, name);
+  if(state){
+    throw new Error('Unexpected sold out state');
+  }
+});
+
+Then('the shop should list at most {int} upgrades', async max => {
+  const count = await ctx.page.$$eval('#shop-overlay .shop-item', items => items.length);
+  if(count > max){
+    throw new Error(`Expected at most ${max} items but got ${count}`);
+  }
+});

--- a/features/step_definitions/world.js
+++ b/features/step_definitions/world.js
@@ -259,6 +259,16 @@ When('I spawn the trader ship at offset {int} {int} from the ship', async (dx, d
   await ctx.page.waitForTimeout(50);
 });
 
+When('I spawn the trader ship with inventory {string}', async inv => {
+  await ctx.page.waitForFunction(() => window.gameScene && window.gameScene.spawnTraderShip);
+  await ctx.page.evaluate(i => {
+    const gs = window.gameScene;
+    const invObj = JSON.parse(i);
+    gs.spawnTraderShip(gs.ship.x, gs.ship.y, 1, invObj);
+  }, inv);
+  await ctx.page.waitForTimeout(50);
+});
+
 When('I record the trader ship position', async () => {
   await ctx.page.waitForFunction(() => window.gameScene?.traderShip);
   ctx.lastTraderPos = await ctx.page.evaluate(() => ({ x: window.gameScene.traderShip.x, y: window.gameScene.traderShip.y }));

--- a/features/trader_inventory.feature
+++ b/features/trader_inventory.feature
@@ -1,0 +1,23 @@
+Feature: Trader limited inventory
+  Scenario: Buying out the stock marks it sold out
+    Given I open the game page
+    When I spawn the trader ship with inventory "{\"max_ammo\":1}"
+    And I click the start screen
+    Then the game should appear after a short delay
+    And I wait for 2100 ms
+    Then the shop overlay should be visible
+    When I click buy on the upgrade "Max Ammo"
+    Then the upgrade "Max Ammo" should show Sold Out
+
+  Scenario: Stock resets for a new trader
+    Given I open the game page
+    When I spawn the trader ship with inventory "{\"max_ammo\":1}"
+    And I click the start screen
+    Then the game should appear after a short delay
+    And I wait for 2100 ms
+    When I click buy on the upgrade "Max Ammo"
+    Then the upgrade "Max Ammo" should show Sold Out
+    When I click the undock button
+    And I spawn the trader ship with inventory "{\"max_ammo\":1}"
+    And I wait for 2100 ms
+    Then the upgrade "Max Ammo" should not show Sold Out

--- a/static/css/components/overlays.css
+++ b/static/css/components/overlays.css
@@ -120,6 +120,14 @@
     padding: 2px 6px;
 }
 
+#shop-overlay .shop-item.sold-out {
+    opacity: 0.5;
+}
+
+#shop-overlay .shop-item.sold-out .buy-btn {
+    cursor: default;
+}
+
 #shop-coming {
     margin-top: 10px;
     font-style: italic;

--- a/static/lib/game/loop.js
+++ b/static/lib/game/loop.js
@@ -357,6 +357,7 @@
             this.traderShip.destroy();
             this.traderShip = null;
             this.nextTraderSpawn = time + this.traderSpawnInterval;
+            window.shop.render(null);
         }
     }
 

--- a/static/lib/game/scene.js
+++ b/static/lib/game/scene.js
@@ -199,10 +199,22 @@
     this.traderShip = null;
     this.traderSpawnInterval = window.traderInterval || 20000;
     this.nextTraderSpawn = this.traderSpawnInterval;
-    this.spawnTraderShip = (x, y, dir = 1) => {
+    function randomInventory(){
+        const ids = window.shop.items.map(i => i.id);
+        Phaser.Utils.Array.Shuffle(ids);
+        const count = Phaser.Math.Between(2, ids.length);
+        const inv = {};
+        for(let i=0;i<count;i++){
+            inv[ids[i]] = Phaser.Math.Between(1,3);
+        }
+        return inv;
+    }
+
+    this.spawnTraderShip = (x, y, dir = 1, inv = null) => {
         if (this.traderShip) this.traderShip.destroy();
         const container = this.add.container(x, y);
-        const body = this.add.rectangle(0, 0, 80, 30, 0x808080);
+        const color = Phaser.Display.Color.RandomRGB().color;
+        const body = this.add.rectangle(0, 0, 80, 30, color);
         const cockpit = this.add.triangle(40 * dir, 0, 20 * dir, -15, 60 * dir, 0, 20 * dir, 15, 0xcccccc);
         const flame = this.add.triangle(-50 * dir, 0, -10 * dir, -5, -20 * dir, 0, -10 * dir, 5, 0xffa500);
         container.add([body, cockpit, flame]);
@@ -210,9 +222,10 @@
         container.dir = dir;
         container.baseSpeed = 40;
         container.speed = container.baseSpeed;
+        container.inventory = inv || randomInventory();
         this.traderShip = container;
     };
-    window.spawnTraderShip = (x, y, dir) => this.spawnTraderShip(x, y, dir);
+    window.spawnTraderShip = (x, y, dir, inv) => this.spawnTraderShip(x, y, dir, inv);
 
     // Docking helpers
     this.dockingStart = null;
@@ -242,6 +255,7 @@
         if(this.shopOverlay){
             this.shopOverlay.classList.add('open');
             updateShopStatsPanel();
+            window.shop.render(this.traderShip.inventory);
         }
         window.pauseGame();
     };
@@ -253,6 +267,10 @@
         if(this.shopOverlay){
             this.shopOverlay.classList.remove('open');
         }
+        if(this.traderShip){
+            this.traderShip.inventory = null;
+        }
+        window.shop.render(null);
         window.resumeGame();
     };
 

--- a/static/lib/shop.js
+++ b/static/lib/shop.js
@@ -6,7 +6,12 @@
     { id: 'shield', name: 'Shield', cost: 5, desc: 'Start with a shield' }
   ];
 
+  let currentInventory = null;
+
   function purchase(item){
+    if(item && currentInventory && currentInventory[item.id] !== undefined){
+      if(currentInventory[item.id] <= 0) return false;
+    }
     if(window.totalCredits < item.cost) return false;
     window.totalCredits -= item.cost;
     storage.setCredits(window.totalCredits);
@@ -15,16 +20,22 @@
     });
     window.permanentUpgrades.push(item.id);
     storage.setPermanentUpgrades(window.permanentUpgrades);
+    if(currentInventory && currentInventory[item.id] !== undefined){
+      currentInventory[item.id] -= 1;
+    }
     updateInventoryPanel();
     updateShopStatsPanel();
+    buildList();
     return true;
   }
 
-  function buildList(){
+  function buildList(inventory){
+    if(inventory !== undefined) currentInventory = inventory;
     const container = document.getElementById('shop-items');
     if(!container) return;
     container.innerHTML = '';
-    for(const item of items){
+    const list = currentInventory ? items.filter(it => currentInventory[it.id] !== undefined) : items;
+    for(const item of list){
       const li = document.createElement('li');
       li.className = 'shop-item';
       const icon = document.createElement('span');
@@ -42,6 +53,12 @@
       btn.className = 'buy-btn';
       btn.textContent = 'Buy';
       btn.addEventListener('click', () => purchase(item));
+      const stock = currentInventory ? currentInventory[item.id] : Infinity;
+      if(stock <= 0){
+        li.classList.add('sold-out');
+        btn.disabled = true;
+        btn.textContent = 'Sold Out';
+      }
       li.appendChild(icon);
       li.appendChild(name);
       li.appendChild(desc);


### PR DESCRIPTION
## Summary
- randomize trader inventory when spawned and consume stock on purchase
- display sold-out items in shop overlay
- clear inventory when undocking or trader despawns
- add CSS styling for sold-out items
- support predefined inventories in BDD tests
- test trader inventory behaviour

## Testing
- `npm run check`
- `npm test` *(fails: ERR_IPC_CHANNEL_CLOSED)*

------
https://chatgpt.com/codex/tasks/task_e_68554b3bf48c832b92bb9ea58e3b85f3