### PR TITLE
Add orbiting power-up logic

### DIFF
--- a/features/powerup_orbit.feature
+++ b/features/powerup_orbit.feature
@@ -1,0 +1,11 @@
+Feature: Power-up orbit
+  Scenario: Power-ups spawn in orbit and move around the planet
+    Given I open the game page
+    When I click the start screen
+    Then the game should appear after a short delay
+    When I set the next power-up spawn to 0 ms
+    And I wait for 100 ms
+    Then a power-up should be visible
+    When I record the power-up position
+    And I wait for 1200 ms
+    Then the power-up should have moved

--- a/features/step_definitions/context.js
+++ b/features/step_definitions/context.js
@@ -6,5 +6,6 @@ module.exports = {
   lastPointer: { x: 0, y: 0 },
   initialAmmo: 0,
   lastOrbPos: null,
-  lastTraderPos: null
+  lastTraderPos: null,
+  lastPowerupPos: null
 };

--- a/static/lib/game/loop.js
+++ b/static/lib/game/loop.js
@@ -147,8 +147,11 @@
     }
 
     if (time > this.nextPowerUpSpawn) {
-        const x = Phaser.Math.Between(20, this.scale.width - 20);
-        const y = Phaser.Math.Between(20, this.scale.height - 20);
+        const center = this.powerUpOrbitCenter || this.planets[0]?.sprite;
+        const radius = this.powerUpOrbitRadius || 180;
+        const angle = Phaser.Math.FloatBetween(0, Math.PI * 2);
+        const x = center.x + Math.cos(angle) * radius;
+        const y = center.y + Math.sin(angle) * radius;
         const type = Phaser.Math.RND.pick(['ammo', 'fuel', 'time']);
         let color = 0xffff00;
         if (type === 'fuel') color = 0xffa500;
@@ -171,7 +174,7 @@
         }
         this.tweens.add({ targets: power, scale: 1.1, yoyo: true, repeat: -1, duration: 800 });
         power.setAlpha(1);
-        this.powerUps.push({ sprite: power, type: type, spawnTime: time });
+        this.powerUps.push({ sprite: power, type: type, spawnTime: time, angle, orbiting: true });
         this.nextPowerUpSpawn = time + this.powerUpSpawnRate;
     }
 
@@ -263,6 +266,14 @@
 
     for (let i = this.powerUps.length - 1; i >= 0; i--) {
         const p = this.powerUps[i];
+        if (p.orbiting !== false) {
+            const center = this.powerUpOrbitCenter || this.planets[0]?.sprite;
+            const radius = this.powerUpOrbitRadius || 180;
+            p.angle += this.powerUpAngularSpeed * deltaSeconds * this.powerUpOrbitDir;
+            p.sprite.x = center.x + Math.cos(p.angle) * radius;
+            p.sprite.y = center.y + Math.sin(p.angle) * radius;
+        }
+
         const progress = (time - p.spawnTime) / this.powerUpFadeDuration;
         p.sprite.setAlpha(1 - progress);
         if (progress >= 1) {

--- a/static/lib/game/scene.js
+++ b/static/lib/game/scene.js
@@ -95,6 +95,12 @@
     const planet = this.add.circle(pos.x, pos.y, pr, 0x6666ff);
     this.planets.push({ sprite: planet, radius: pr, atmosphere });
 
+    // Power-up orbit parameters
+    this.powerUpOrbitCenter = planet;
+    this.powerUpOrbitRadius = pr + 60;
+    this.powerUpAngularSpeed = 0.25; // radians per second
+    this.powerUpOrbitDir = Math.random() < 0.5 ? 1 : -1;
+
     this.spawnOrb = (color, t) => {
         const x = Phaser.Math.Between(0, this.scale.width);
         const y = Phaser.Math.Between(0, this.scale.height);


### PR DESCRIPTION
## Summary
- make power-ups orbit planets at a fixed radius
- keep manual test power-ups stationary
- add steps to control and verify orbiting power-ups
- test that power-ups move in orbit

## Testing
- `npm run check`
- `npx cucumber-js features/powerup_orbit.feature --format progress`
- `npx cucumber-js --format progress` *(fails: Target page, context or browser has been closed)*

------
https://chatgpt.com/codex/tasks/task_e_68554b0fc504832b962b9ed8077b25c6