### PR TITLE
Make credits run-scoped

### DIFF
--- a/features/step_definitions/economy.js
+++ b/features/step_definitions/economy.js
@@ -26,8 +26,7 @@ Then('each upgrade should appear as a card', async () => {
 
 Given('I have {int} credits', async count => {
   await ctx.page.evaluate(c => {
-    localStorage.setItem('credits', c);
-    window.totalCredits = c;
+    window.runCredits = c;
     document.querySelectorAll('.total-credits, #start-credits-value').forEach(el => { el.textContent = c; });
   }, count);
 });

--- a/static/lib/boot.js
+++ b/static/lib/boot.js
@@ -22,9 +22,9 @@
 
   const storedHigh = storage.getHighscore();
   document.getElementById('highscore-value').textContent = storedHigh;
-  window.totalCredits = storage.getCredits();
+  window.runCredits = 0;
   document.querySelectorAll('.total-credits, #start-credits-value').forEach(el => {
-    el.textContent = window.totalCredits;
+    el.textContent = window.runCredits;
   });
 
   window.permanentUpgrades = storage.getPermanentUpgrades();
@@ -40,7 +40,7 @@
 
   function resetProgress(){
     storage.resetAll();
-    window.totalCredits = 0;
+    window.runCredits = 0;
     window.permanentUpgrades = [];
     window.sessionUpgrades = [];
     document.querySelectorAll('.total-credits, #start-credits-value').forEach(el => { el.textContent = 0; });

--- a/static/lib/game/scene.js
+++ b/static/lib/game/scene.js
@@ -124,10 +124,9 @@
             this.streak += 1;
             this.score += 10 * this.streak;
             this.credits += 1;
-            window.totalCredits += 1;
-            localStorage.setItem('credits', window.totalCredits);
+            window.runCredits += 1;
             document.querySelectorAll('.total-credits, #start-credits-value').forEach(el => {
-                el.textContent = window.totalCredits;
+                el.textContent = window.runCredits;
             });
             if (this.streak % 5 === 0) {
                 const txt = this.add.text(x, y, `Streak ${this.streak}!`, { font: '20px Arial', color: '#ff00ff' });

--- a/static/lib/shop.js
+++ b/static/lib/shop.js
@@ -12,11 +12,10 @@
     if(item && currentInventory && currentInventory[item.id] !== undefined){
       if(currentInventory[item.id] <= 0) return false;
     }
-    if(window.totalCredits < item.cost) return false;
-    window.totalCredits -= item.cost;
-    storage.setCredits(window.totalCredits);
+    if(window.runCredits < item.cost) return false;
+    window.runCredits -= item.cost;
     document.querySelectorAll('.total-credits, #start-credits-value').forEach(el => {
-      el.textContent = window.totalCredits;
+      el.textContent = window.runCredits;
     });
     window.permanentUpgrades.push(item.id);
     storage.setPermanentUpgrades(window.permanentUpgrades);


### PR DESCRIPTION
## Summary
- make credits reset at the start of a run
- let shop purchases and orb hits modify run-scoped credits
- update tests for session-based credits

## Testing
- `npm run check`
- `npm test` *(fails: ERR_IPC_CHANNEL_CLOSED)*

------
https://chatgpt.com/codex/tasks/task_e_68554db805bc832baaddee83c55eb4ca