### PR TITLE
Implement incremental ship upgrades

### DIFF
--- a/features/shop_purchase.feature
+++ b/features/shop_purchase.feature
@@ -4,7 +4,7 @@ Feature: Purchasing upgrades
     And I have 5 credits
     When I buy the upgrade "Max Ammo"
     Then the displayed credits should be 0
-    And the inventory stat "Ammo Limit" should be "100"
+    And the inventory stat "Ammo Limit" should be "55"
     When I click the start screen
     Then the game should appear after a short delay
-    And my ammo should be 100
+    And my ammo should be 55

--- a/static/lib/game/scene.js
+++ b/static/lib/game/scene.js
@@ -9,25 +9,18 @@
     this.velocity = new Phaser.Math.Vector2(0, 0);
     this.isBoosting = false;
     this.isFiring = false;
-    this.maxFuel = window.baseStats.maxFuel;
-    this.fuel = this.maxFuel;
-    this.ammo = window.baseStats.ammo;
-    this.boostThrust = window.baseStats.boostThrust;
+    const stats = window.getCurrentStats();
+    this.maxFuel = stats.fuel;
+    this.fuel = stats.fuel;
+    this.ammo = stats.ammo;
+    this.boostThrust = stats.thrust;
     this.credits = 0;
-    this.fireRate = 100;
+    this.fireRate = stats.reload;
     this.lastFired = 0;
     this.bullets = [];
     this.gameOver = false;
 
-    const upgrades = [...window.permanentUpgrades, ...window.sessionUpgrades];
-    this.shield = upgrades.includes('shield');
-    const fuelUps = upgrades.filter(u => u === 'extra_fuel').length;
-    this.maxFuel += fuelUps * 50;
-    this.fuel = this.maxFuel;
-    const reloadUps = upgrades.filter(u => u === 'fast_reload').length;
-    this.fireRate = Math.max(20, this.fireRate - reloadUps * 10);
-    const ammoUps = upgrades.filter(u => u === 'max_ammo').length;
-    this.ammo += ammoUps * 50;
+    this.shield = stats.shield > 0;
 
     // Timer and power-ups
     this.timeRemaining = 60;

--- a/static/lib/shop.js
+++ b/static/lib/shop.js
@@ -1,8 +1,8 @@
 (function(){
   const items = [
-    { id: 'extra_fuel', name: 'Extra Fuel', cost: 5, desc: '+50 Fuel Capacity' },
-    { id: 'max_ammo', name: 'Max Ammo', cost: 5, desc: '+50 Ammo Limit' },
-    { id: 'fast_reload', name: 'Fast Reload', cost: 5, desc: 'Reload 10 faster' },
+    { id: 'extra_fuel', name: 'Extra Fuel', cost: 5, desc: '+5 Fuel Capacity' },
+    { id: 'max_ammo', name: 'Max Ammo', cost: 5, desc: '+5 Ammo Limit' },
+    { id: 'fast_reload', name: 'Fast Reload', cost: 5, desc: 'Reload 2% faster' },
     { id: 'shield', name: 'Shield', cost: 5, desc: 'Start with a shield' }
   ];
 

--- a/static/lib/stats.js
+++ b/static/lib/stats.js
@@ -15,9 +15,9 @@
     let shield = baseStats.shieldDuration;
     const active = [...(window.permanentUpgrades || []), ...(window.sessionUpgrades || [])];
     for (const id of active) {
-      if (id === 'extra_fuel') fuel += 50;
-      else if (id === 'max_ammo') ammo += 50;
-      else if (id === 'fast_reload') reload = Math.max(20, reload - 10);
+      if (id === 'extra_fuel') fuel += 5;
+      else if (id === 'max_ammo') ammo += 5;
+      else if (id === 'fast_reload') reload = Math.max(20, Math.round(reload * 0.98));
       else if (id === 'shield') shield = 1;
     }
     return {fuel, ammo, thrust, reload, shield};
@@ -66,10 +66,13 @@
     let statKey;
     if(item.id === 'extra_fuel'){
       statKey = 'fuel';
-      preview.fuel += 50;
+      preview.fuel += 5;
     }else if(item.id === 'max_ammo'){
       statKey = 'ammo';
-      preview.ammo += 50;
+      preview.ammo += 5;
+    }else if(item.id === 'fast_reload'){
+      statKey = 'reload';
+      preview.reload = Math.max(20, Math.round(preview.reload * 0.98));
     }else if(item.id === 'shield'){
       statKey = 'shield';
       preview.shield = 1;


### PR DESCRIPTION
## Summary
- implement small incremental upgrade boosts
- show upgrade preview for reload speed
- compute stats directly from getCurrentStats in scene
- adjust shop purchase test for new numbers

## Testing
- `npm run check`
- `npx playwright install --with-deps`
- `npm test` *(fails: browser.newContext: Target page, context or browser has been closed)*

------
https://chatgpt.com/codex/tasks/task_e_6855527ba330832bbb5a981fb8b8e465