### PR TITLE
Add incremental upgrade effects and cooldown UI

### DIFF
--- a/features/inventory_panel.feature
+++ b/features/inventory_panel.feature
@@ -4,7 +4,7 @@ Feature: Inventory panel
     Then the inventory panel should be visible
     And the inventory stat "Fuel Capacity" should be "200"
     And the inventory stat "Ammo Limit" should be "50"
-    And the inventory stat "Reload Time" should be "100"
+    And the inventory stat "Reload Time" should be "3500"
     And the inventory stat "Boost Thrust" should be "200"
     And the inventory stat "Shield Duration" should be "0"
 

--- a/features/laser_firing.feature
+++ b/features/laser_firing.feature
@@ -7,3 +7,11 @@ Feature: Laser firing
     Then bullets should be fired
     And the ammo should decrease
     When I release the left mouse button
+
+  Scenario: Cooldown indicator shown when firing
+    Given I open the game page
+    When I click the start screen
+    Then the game should appear after a short delay
+    When I hold the left mouse button for 100 ms
+    Then the cooldown indicator should be visible
+    When I release the left mouse button

--- a/features/powerup_pickup.feature
+++ b/features/powerup_pickup.feature
@@ -20,8 +20,8 @@ Feature: Power-up pickups
     Given I open the game page
     When I click the start screen
     Then the game should appear after a short delay
-    When I spawn an ammo power-up offset by 100 0 from the ship
-    When I wait for 9000 ms
+    When I spawn an ammo power-up offset by 150 0 from the ship
+    When I wait for 8000 ms
     Then a power-up should be visible
-    When I wait for 4000 ms
+    When I wait for 6000 ms
     Then no power-ups should be visible

--- a/features/shop_purchase.feature
+++ b/features/shop_purchase.feature
@@ -4,7 +4,7 @@ Feature: Purchasing upgrades
     And I have 5 credits
     When I buy the upgrade "Max Ammo"
     Then the displayed credits should be 0
-    And the inventory stat "Ammo Limit" should be "55"
+    And the inventory stat "Ammo Limit" should be "75"
     When I click the start screen
     Then the game should appear after a short delay
-    And my ammo should be 55
+    And my ammo should be 75

--- a/features/step_definitions/combat.js
+++ b/features/step_definitions/combat.js
@@ -82,3 +82,22 @@ Then('the ship should face the reticle', async () => {
     return diff < 0.2;
   }, ctx.lastPointer);
 });
+
+When('I set the ship boost thrust to {int}', async thrust => {
+  await ctx.page.waitForFunction(() => window.gameScene);
+  await ctx.page.evaluate(t => { window.gameScene.boostThrust = t; }, thrust);
+});
+
+Then('the flame scale should be {float}', async expected => {
+  const scale = await ctx.page.evaluate(() => window.gameScene.flame.scaleY);
+  if (Math.abs(scale - expected) > 0.1) {
+    throw new Error(`Flame scale ${scale} not close to ${expected}`);
+  }
+});
+
+Then('the cooldown indicator should be visible', async () => {
+  const display = await ctx.page.$eval('#reload-indicator', el => getComputedStyle(el).display);
+  if (display === 'none') {
+    throw new Error('Cooldown indicator not visible');
+  }
+});

--- a/features/thruster_boost.feature
+++ b/features/thruster_boost.feature
@@ -26,3 +26,15 @@ Feature: Thruster Boost
     When I hold the right mouse button for 500 ms
     When I release the right mouse button
     Then the ship speed should be below 150
+
+  Scenario: Flame scales with thrust
+    Given I open the game page
+    When I click the start screen
+    Then the game should appear after a short delay
+    When I hold the right mouse button for 300 ms
+    Then the flame scale should be 1
+    When I release the right mouse button
+    When I set the ship boost thrust to 400
+    When I hold the right mouse button for 300 ms
+    Then the flame scale should be 2
+    When I release the right mouse button

--- a/features/trader_inventory.feature
+++ b/features/trader_inventory.feature
@@ -1,9 +1,10 @@
 Feature: Trader limited inventory
   Scenario: Buying out the stock marks it sold out
     Given I open the game page
-    When I spawn the trader ship with inventory "{\"max_ammo\":1}"
+    And I have 5 credits
     And I click the start screen
     Then the game should appear after a short delay
+    When I spawn the trader ship with inventory "{\"max_ammo\":1}"
     And I wait for 2100 ms
     Then the shop overlay should be visible
     When I click buy on the upgrade "Max Ammo"
@@ -11,9 +12,10 @@ Feature: Trader limited inventory
 
   Scenario: Stock resets for a new trader
     Given I open the game page
-    When I spawn the trader ship with inventory "{\"max_ammo\":1}"
+    And I have 5 credits
     And I click the start screen
     Then the game should appear after a short delay
+    When I spawn the trader ship with inventory "{\"max_ammo\":1}"
     And I wait for 2100 ms
     When I click buy on the upgrade "Max Ammo"
     Then the upgrade "Max Ammo" should show Sold Out

--- a/features/trader_ship.feature
+++ b/features/trader_ship.feature
@@ -27,7 +27,7 @@ Feature: Trader ship sightings
     Then the game should appear after a short delay
     When I place the ship at 300 300 with velocity 0 0
     And I spawn the trader ship on the ship
-    And I wait for 2100 ms
+    And I wait for 2500 ms
     Then the docking banner should be visible
     And the game should be paused
     When I click the undock button
@@ -41,6 +41,6 @@ Feature: Trader ship sightings
     Then the game should appear after a short delay
     When I place the ship at 300 300 with velocity 0 0
     And I spawn the trader ship at offset 45 0 from the ship
-    And I wait for 2100 ms
+    And I wait for 2500 ms
     Then the docking banner should be visible
     And the game should be paused

--- a/index.html
+++ b/index.html
@@ -45,6 +45,7 @@
     <div id="urgency-overlay"></div>
     <div id="fuel-container"><div id="fuel-bar"></div></div>
     <div id="ammo-container">Ammo: <span id="ammo-count">0</span></div>
+    <div id="reload-indicator"><div class="fill"></div></div>
     <div id="credits-container">Credits: <span id="credits">0</span></div>
     <div id="score-container">Score: <span id="score">0</span> | Streak: <span id="streak">0</span> | Time: <span id="time-remaining">60</span></div>
     <div id="level-banner"></div>

--- a/static/css/game.css
+++ b/static/css/game.css
@@ -32,6 +32,20 @@
     font-family: Arial, sans-serif;
     display: none;
 }
+#reload-indicator {
+    position: absolute;
+    top: 28px;
+    right: 10px;
+    width: 100px;
+    height: 6px;
+    border: 1px solid #fff;
+    display: none;
+}
+#reload-indicator .fill {
+    height: 100%;
+    width: 0;
+    background: yellow;
+}
 #credits-container {
     position: absolute;
     top: 50px;

--- a/static/lib/boot.js
+++ b/static/lib/boot.js
@@ -88,6 +88,7 @@
     const game = new Phaser.Game(config);
     document.getElementById('fuel-container').style.display = 'block';
     document.getElementById('ammo-container').style.display = 'block';
+    document.getElementById('reload-indicator').style.display = 'block';
     document.getElementById('credits-container').style.display = 'block';
     document.getElementById('score-container').style.display = 'block';
     document.getElementById('legend').style.display = 'block';

--- a/static/lib/game/loop.js
+++ b/static/lib/game/loop.js
@@ -84,6 +84,9 @@
     this.flame.visible = this.isBoosting && this.fuel > 0;
     if (this.flame.visible) {
         this.flame.rotation = this.ship.rotation;
+        const scale = this.boostThrust / window.baseStats.boostThrust;
+        this.flame.scaleX = scale;
+        this.flame.scaleY = scale;
         this.flame.x = this.ship.x - Math.cos(noseAngle) * 20;
         this.flame.y = this.ship.y - Math.sin(noseAngle) * 20;
     }
@@ -426,6 +429,15 @@
     document.getElementById('streak').textContent = this.streak;
     document.getElementById('credits').textContent = this.credits;
     document.getElementById('time-remaining').textContent = Math.ceil(this.timeRemaining);
+    const cd = document.getElementById('reload-indicator');
+    const fill = cd.querySelector('.fill');
+    const prog = Math.min(1, (time - this.lastFired) / this.fireRate);
+    if (prog < 1) {
+        cd.style.display = 'block';
+        fill.style.width = (prog * 100) + '%';
+    } else {
+        cd.style.display = 'none';
+    }
 }
   window.gameUpdate = update;
 })();

--- a/static/lib/shop.js
+++ b/static/lib/shop.js
@@ -1,8 +1,9 @@
 (function(){
   const items = [
-    { id: 'extra_fuel', name: 'Extra Fuel', cost: 5, desc: '+5 Fuel Capacity' },
-    { id: 'max_ammo', name: 'Max Ammo', cost: 5, desc: '+5 Ammo Limit' },
-    { id: 'fast_reload', name: 'Fast Reload', cost: 5, desc: 'Reload 2% faster' },
+    { id: 'extra_fuel', name: 'Extra Fuel', cost: 5, desc: '+25 Fuel Capacity' },
+    { id: 'max_ammo', name: 'Max Ammo', cost: 5, desc: '+25 Ammo Limit' },
+    { id: 'boost_thrust', name: 'Boost Thrusters', cost: 5, desc: '+25 Boost Thrust' },
+    { id: 'fast_reload', name: 'Fast Reload', cost: 5, desc: 'Reload 0.2s faster' },
     { id: 'shield', name: 'Shield', cost: 5, desc: 'Start with a shield' }
   ];
 

--- a/static/lib/stats.js
+++ b/static/lib/stats.js
@@ -3,7 +3,7 @@
     maxFuel: 200,
     ammo: 50,
     boostThrust: 200,
-    reloadTime: 100,
+    reloadTime: 3500,
     shieldDuration: 0
   };
 
@@ -15,9 +15,10 @@
     let shield = baseStats.shieldDuration;
     const active = [...(window.permanentUpgrades || []), ...(window.sessionUpgrades || [])];
     for (const id of active) {
-      if (id === 'extra_fuel') fuel += 5;
-      else if (id === 'max_ammo') ammo += 5;
-      else if (id === 'fast_reload') reload = Math.max(20, Math.round(reload * 0.98));
+      if (id === 'extra_fuel') fuel += 25;
+      else if (id === 'max_ammo') ammo += 25;
+      else if (id === 'boost_thrust') thrust += 25;
+      else if (id === 'fast_reload') reload = Math.max(200, reload - 200);
       else if (id === 'shield') shield = 1;
     }
     return {fuel, ammo, thrust, reload, shield};
@@ -35,6 +36,7 @@
     for(const id of active){
       if(id === 'extra_fuel') invest.fuel += map[id] || 0;
       else if(id === 'max_ammo') invest.ammo += map[id] || 0;
+      else if(id === 'boost_thrust') invest.thrust += map[id] || 0;
       else if(id === 'fast_reload') invest.reload += map[id] || 0;
       else if(id === 'shield') invest.shield += map[id] || 0;
     }
@@ -66,13 +68,16 @@
     let statKey;
     if(item.id === 'extra_fuel'){
       statKey = 'fuel';
-      preview.fuel += 5;
+      preview.fuel += 25;
     }else if(item.id === 'max_ammo'){
       statKey = 'ammo';
-      preview.ammo += 5;
+      preview.ammo += 25;
+    }else if(item.id === 'boost_thrust'){
+      statKey = 'thrust';
+      preview.thrust += 25;
     }else if(item.id === 'fast_reload'){
       statKey = 'reload';
-      preview.reload = Math.max(20, Math.round(preview.reload * 0.98));
+      preview.reload = Math.max(200, preview.reload - 200);
     }else if(item.id === 'shield'){
       statKey = 'shield';
       preview.shield = 1;


### PR DESCRIPTION
## Summary
- tune upgrade values and add thruster upgrade
- enlarge boost flame based on thrust
- display reload cooldown progress bar
- adjust BDD scenarios for new stat values and effects

## Testing
- `npm run check`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68555662023c832b96946d53e27c78db