### PR TITLE
Expand shop overlay width

### DIFF
--- a/features/shop_overlay.feature
+++ b/features/shop_overlay.feature
@@ -9,6 +9,7 @@ Feature: Shop overlay
     And I wait for 2100 ms
     Then the docking banner should be visible
     And the shop overlay should be visible
+    And the shop overlay width should be at least 320 px
     And the shop credits should be 0
     And the shop stat "Ammo Limit" should be "50"
     When I click the undock button

--- a/features/step_definitions/shop.js
+++ b/features/step_definitions/shop.js
@@ -59,3 +59,10 @@ Then('the shop should list at most {int} upgrades', async max => {
     throw new Error(`Expected at most ${max} items but got ${count}`);
   }
 });
+
+Then('the shop overlay width should be at least {int}px', async min => {
+  const width = await ctx.page.$eval('#shop-overlay', el => parseInt(getComputedStyle(el).width));
+  if (width < min) {
+    throw new Error(`Expected width at least ${min} but got ${width}`);
+  }
+});

--- a/static/css/components/overlays.css
+++ b/static/css/components/overlays.css
@@ -62,8 +62,8 @@
 #shop-overlay {
     position: absolute;
     top: 0;
-    right: -260px;
-    width: 260px;
+    right: -320px;
+    width: 320px;
     height: 100%;
     background: rgba(0, 0, 0, 0.8);
     color: #fff;
@@ -81,11 +81,12 @@
 #shop-overlay h2 {
     margin-top: 0;
     text-align: center;
-    font-size: 20px;
+    font-size: 24px;
 }
 
 #shop-overlay h3 {
     margin-bottom: 6px;
+    font-size: 18px;
 }
 
 #shop-overlay ul {
@@ -95,8 +96,8 @@
 }
 
 #shop-overlay li {
-    font-size: 14px;
-    margin-bottom: 4px;
+    font-size: 16px;
+    margin-bottom: 6px;
 }
 
 #shop-overlay li.fuel::before { content: '⛽'; margin-right: 4px; }
@@ -107,17 +108,17 @@
 #shop-overlay .shop-item {
     display: flex;
     align-items: center;
-    gap: 4px;
+    gap: 8px;
 }
 #shop-overlay .price-badge {
     margin-left: auto;
     background: #333;
-    padding: 2px 4px;
+    padding: 4px 6px;
     border-radius: 4px;
 }
 #shop-overlay .buy-btn {
-    margin-left: 4px;
-    padding: 2px 6px;
+    margin-left: 8px;
+    padding: 4px 8px;
 }
 
 #shop-overlay .shop-item.sold-out {


### PR DESCRIPTION
## Summary
- enlarge the shop overlay to 320px wide and adjust layout for readability
- verify the overlay width with a BDD step and add it to the shop overlay scenario

## Testing
- `npm run check`
- `npm test` *(fails: ERR_IPC_CHANNEL_CLOSED)*

------
https://chatgpt.com/codex/tasks/task_e_68555c9f4fe4832bb8180719cd2832b3