### PR TITLE
Tune base stats and adjust tests

### DIFF
--- a/features/inventory_panel.feature
+++ b/features/inventory_panel.feature
@@ -2,10 +2,10 @@ Feature: Inventory panel
   Scenario: Baseline stats displayed on the start screen
     Given I open the game page
     Then the inventory panel should be visible
-    And the inventory stat "Fuel Capacity" should be "200"
-    And the inventory stat "Ammo Limit" should be "50"
+    And the inventory stat "Fuel Capacity" should be "25"
+    And the inventory stat "Ammo Limit" should be "25"
     And the inventory stat "Reload Time" should be "3500"
-    And the inventory stat "Boost Thrust" should be "200"
+    And the inventory stat "Boost Thrust" should be "100"
     And the inventory stat "Shield Duration" should be "0"
 
   Scenario: Stat icons are shown next to values

--- a/features/shop_overlay.feature
+++ b/features/shop_overlay.feature
@@ -10,7 +10,7 @@ Feature: Shop overlay
     Then the docking banner should be visible
     And the shop overlay should be visible
     And the shop credits should be 0
-    And the shop stat "Ammo Limit" should be "50"
+    And the shop stat "Ammo Limit" should be "25"
     When I click the undock button
     Then the shop overlay should not be visible
     And the docking banner should not be visible

--- a/features/shop_purchase.feature
+++ b/features/shop_purchase.feature
@@ -4,7 +4,7 @@ Feature: Purchasing upgrades
     And I have 5 credits
     When I buy the upgrade "Max Ammo"
     Then the displayed credits should be 0
-    And the inventory stat "Ammo Limit" should be "75"
+    And the inventory stat "Ammo Limit" should be "50"
     When I click the start screen
     Then the game should appear after a short delay
-    And my ammo should be 75
+    And my ammo should be 50

--- a/features/step_definitions/combat.js
+++ b/features/step_definitions/combat.js
@@ -23,7 +23,8 @@ Then('the flame should be visible', async () => {
 
 Then('the fuel should decrease', async () => {
   const fuel = await ctx.page.evaluate(() => window.gameScene.fuel);
-  if (fuel >= 200) {
+  const max = await ctx.page.evaluate(() => window.baseStats.maxFuel);
+  if (fuel >= max) {
     throw new Error('Fuel did not decrease');
   }
 });
@@ -50,7 +51,8 @@ Then('bullets should be fired', async () => {
 
 Then('the ammo should decrease', async () => {
   const ammo = await ctx.page.evaluate(() => window.gameScene.ammo);
-  if (ammo >= 50) {
+  const base = await ctx.page.evaluate(() => window.baseStats.ammo);
+  if (ammo >= base) {
     throw new Error('Ammo did not decrease');
   }
 });

--- a/features/thruster_boost.feature
+++ b/features/thruster_boost.feature
@@ -34,7 +34,7 @@ Feature: Thruster Boost
     When I hold the right mouse button for 300 ms
     Then the flame scale should be 1
     When I release the right mouse button
-    When I set the ship boost thrust to 400
+    When I set the ship boost thrust to 200
     When I hold the right mouse button for 300 ms
     Then the flame scale should be 2
     When I release the right mouse button

--- a/static/lib/stats.js
+++ b/static/lib/stats.js
@@ -1,8 +1,8 @@
 (function(){
   const baseStats = {
-    maxFuel: 200,
-    ammo: 50,
-    boostThrust: 200,
+    maxFuel: 25,
+    ammo: 25,
+    boostThrust: 100,
     reloadTime: 3500,
     shieldDuration: 0
   };


### PR DESCRIPTION
## Summary
- lower starting fuel, ammo, and boost thrust
- update UI tests for new baseline values
- update shop baseline ammo stat
- adjust ammo upgrade expectations
- adapt combat step definitions to use base stats
- tweak thrust test value

## Testing
- `npm run check`
- `npx cucumber-js features/inventory_panel.feature`
- `npx cucumber-js features/shop_overlay.feature features/shop_purchase.feature features/thruster_boost.feature`

------
https://chatgpt.com/codex/tasks/task_e_685560ec8bb0832b8803734ffc670567