### PR TITLE
Remove start screen credit display

### DIFF
--- a/features/step_definitions/economy.js
+++ b/features/step_definitions/economy.js
@@ -130,7 +130,7 @@ When('I click the reset button', async () => {
 });
 
 Then('the displayed credits should be {int}', async expected => {
-  const val = await ctx.page.$eval('#start-credits-value', el => parseInt(el.textContent));
+  const val = await ctx.page.evaluate(() => window.runCredits);
   if (val !== expected) {
     throw new Error(`Expected credits ${expected} but got ${val}`);
   }

--- a/index.html
+++ b/index.html
@@ -25,7 +25,6 @@
             <p>Click anywhere to begin!</p>
         </div>
         <div id="highscore-display">Your highscore: <span id="highscore-value">0</span></div>
-        <div id="start-credits-display">Credits: <span id="start-credits-value">0</span></div>
         <div id="inventory-panel">
             <h2>Ship Stats</h2>
             <ul>

--- a/static/css/components/start-screen.css
+++ b/static/css/components/start-screen.css
@@ -18,15 +18,6 @@
     font-family: Arial, sans-serif;
     font-size: 24px;
 }
-#start-credits-display {
-    position: absolute;
-    bottom: 60px;
-    left: 50%;
-    transform: translateX(-50%);
-    color: #fff;
-    font-family: Arial, sans-serif;
-    font-size: 20px;
-}
 #rules {
     position: absolute;
     bottom: 20px;


### PR DESCRIPTION
## Summary
- drop credit counter from the start screen
- update start screen CSS
- assert credits via variable instead of DOM

## Testing
- `npm run check`
- `npm test` *(fails: ERR_IPC_CHANNEL_CLOSED)*

------
https://chatgpt.com/codex/tasks/task_e_685573308dc8832b8b0a82a17d22ca8b