### PR TITLE
Fix ship alignment and hitboxes

### DIFF
--- a/features/step_definitions/world.js
+++ b/features/step_definitions/world.js
@@ -191,9 +191,9 @@ When('I spawn a stationary red orb offset by {int} {int} from the ship', async (
   await ctx.page.waitForFunction(() => window.gameScene && window.gameScene.orbs);
   await ctx.page.evaluate(({ dx, dy }) => {
     const gs = window.gameScene;
-    const orb = gs.add.circle(gs.ship.x + dx, gs.ship.y + dy, 20, 0xff0000);
+    const orb = gs.add.circle(gs.ship.x + dx, gs.ship.y + dy, 16, 0xff0000);
     orb.setScale(1);
-    gs.orbs.push({ sprite: orb, radius: 20, vx: 0, vy: 0, spawnTime: gs.time.now, growing: false });
+    gs.orbs.push({ sprite: orb, radius: 16, vx: 0, vy: 0, spawnTime: gs.time.now, growing: false });
   }, { dx, dy });
   await new Promise(r => setTimeout(r, 300));
 });
@@ -315,6 +315,35 @@ Then('the docking banner should not be visible', async () => {
   const display = await ctx.page.$eval('#dock-banner', el => getComputedStyle(el).display);
   if (display !== 'none') {
     throw new Error('Dock banner should be hidden');
+  }
+});
+
+Then('the trader ship cockpit should be centered', async () => {
+  const ok = await ctx.page.evaluate(() => {
+    const ts = window.gameScene.traderShip;
+    if (!ts) return false;
+    const [, cockpit] = ts.list;
+    return Math.abs(cockpit.x - 40 * ts.dir) < 1 && cockpit.geom.x1 === 0 && cockpit.geom.x3 === 0;
+  });
+  if (!ok) {
+    throw new Error('Cockpit not centered');
+  }
+});
+
+Then('the trader ship wings should be symmetrical', async () => {
+  const ok = await ctx.page.evaluate(() => {
+    const ts = window.gameScene.traderShip;
+    if (!ts) return false;
+    const [body, , w1, w2] = ts.list;
+    const b = body.getBounds();
+    const wb1 = w1.getBounds();
+    const wb2 = w2.getBounds();
+    const dist1 = Math.abs(wb1.centerX - b.centerX);
+    const dist2 = Math.abs(wb2.centerX - b.centerX);
+    return Math.abs(dist1 - dist2) < 1 && Math.abs(wb1.centerY - b.centerY) === Math.abs(wb2.centerY - b.centerY);
+  });
+  if (!ok) {
+    throw new Error('Wings not symmetrical');
   }
 });
 

--- a/features/trader_ship.feature
+++ b/features/trader_ship.feature
@@ -43,4 +43,13 @@ Feature: Trader ship sightings
     And I spawn the trader ship at offset 45 0 from the ship
     And I wait for 2500 ms
     Then the docking banner should be visible
-    And the game should be paused
+  And the game should be paused
+
+  Scenario: Trader ship geometry is aligned
+    Given I open the game page
+    And the trader spawn interval is 100 ms
+    When I click the start screen
+    Then the game should appear after a short delay
+    When I spawn the trader ship on the ship
+    Then the trader ship cockpit should be centered
+    And the trader ship wings should be symmetrical

--- a/static/lib/game/loop.js
+++ b/static/lib/game/loop.js
@@ -235,7 +235,7 @@
             }
         }
         // Check ship collision
-        const shipR = 20;
+        const shipR = this.shipRadius;
         const dx = this.ship.x - o.sprite.x;
         const dy = this.ship.y - o.sprite.y;
         if (dx * dx + dy * dy <= (shipR + radius * o.sprite.scaleX) * (shipR + radius * o.sprite.scaleX)) {
@@ -376,7 +376,7 @@
     for (let p of this.planets) {
         const dxp = this.ship.x - p.sprite.x;
         const dyp = this.ship.y - p.sprite.y;
-        const shipR = 20;
+        const shipR = this.shipRadius;
         if (dxp * dxp + dyp * dyp <= (shipR + p.radius) * (shipR + p.radius)) {
             if (this.shield) {
                 this.shield = false;
@@ -399,7 +399,7 @@
 
     const width = this.scale.width;
     const height = this.scale.height;
-    const shipR = 20;
+    const shipR = this.shipRadius;
     if (this.ship.x - shipR < 0 && this.velocity.x < 0) {
         this.velocity.x *= -1;
         this.ship.x = shipR;

--- a/static/lib/game/scene.js
+++ b/static/lib/game/scene.js
@@ -1,11 +1,12 @@
 (function(){
   function create() {
     window.gameScene = this;
-    // Create a slightly sleeker ship using a polygon with an outline
-    const shipPoints = [0, -25, 20, 20, 0, 10, -20, 20];
+    // Create a slightly smaller ship using a polygon with an outline
+    const shipPoints = [0, -20, 16, 16, 0, 8, -16, 16];
     this.ship = this.add.polygon(400, 300, shipPoints, 0x00ffff);
     this.ship.setStrokeStyle(2, 0xffffff);
     this.ship.setOrigin(0.5, 0.5);
+    this.shipRadius = 16;
 
     this.velocity = new Phaser.Math.Vector2(0, 0);
     this.isBoosting = false;
@@ -98,7 +99,7 @@
     this.spawnOrb = (color, t) => {
         const x = Phaser.Math.Between(0, this.scale.width);
         const y = Phaser.Math.Between(0, this.scale.height);
-        const radius = 20;
+        const radius = 16;
         const orb = this.add.circle(x, y, radius, color);
         orb.setStrokeStyle(2, 0xffffff);
         this.tweens.add({ targets: orb, scale: 1.2, yoyo: true, repeat: -1, duration: 800, delay: this.orbGrowthDuration });
@@ -223,9 +224,9 @@
         const color = Phaser.Display.Color.RandomRGB().color;
         const body = this.add.rectangle(0, 0, 80, 30, color);
         body.setStrokeStyle(2, 0xffffff);
-        const cockpit = this.add.triangle(40 * dir, 0, 20 * dir, -15, 60 * dir, 0, 20 * dir, 15, 0xcccccc);
-        const wing1 = this.add.triangle(-10 * dir, -15, -30 * dir, -25, 10 * dir, -15, -10 * dir, -5, color);
-        const wing2 = this.add.triangle(-10 * dir, 15, -30 * dir, 25, 10 * dir, 15, -10 * dir, 5, color);
+        const cockpit = this.add.triangle(40 * dir, 0, 0, -15, 30 * dir, 0, 0, 15, 0xcccccc);
+        const wing1 = this.add.triangle(0, 0, -20 * dir, -15, -40 * dir, -5, -40 * dir, -25, color);
+        const wing2 = this.add.triangle(0, 0, -20 * dir, 15, -40 * dir, 25, -40 * dir, 5, color);
         const flame = this.add.triangle(-50 * dir, 0, -10 * dir, -5, -20 * dir, 0, -10 * dir, 5, 0xffa500);
         container.add([body, cockpit, wing1, wing2, flame]);
         this.tweens.add({ targets: flame, scaleX: 1.5, yoyo: true, repeat: -1, duration: 300 });


### PR DESCRIPTION
## Summary
- shrink player ship and orb sizes
- center trader ship cockpit and ensure wings are symmetrical
- use `shipRadius` for collisions
- update BDD step definitions and add geometry test

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685571a68390832b98389c633d6ce64c