### PR TITLE
Remove timer mechanic

### DIFF
--- a/features/start_game.feature
+++ b/features/start_game.feature
@@ -12,7 +12,6 @@ Feature: Start the game
     Then the promo animation should be shown
     And the game should appear after a short delay
     And the level should be 1
-  And the time remaining should be 60
 
   Scenario: Star background visible in gameplay
     Given I open the game page

--- a/features/step_definitions/gameplay.js
+++ b/features/step_definitions/gameplay.js
@@ -5,25 +5,6 @@ Given('the level progression interval is {int} ms', async ms => {
   await ctx.page.evaluate(m => { window.levelDuration = m; }, ms);
 });
 
-When('I force the timer below ten seconds', async () => {
-  await ctx.page.evaluate(() => {
-    if (window.gameScene) {
-      window.gameScene.timeRemaining = 9;
-    } else {
-      const ov = document.getElementById('urgency-overlay');
-      if (ov) ov.style.opacity = '0.07';
-    }
-  });
-  await ctx.page.waitForTimeout(1000);
-});
-
-Then('the screen should tint red', async () => {
-  await ctx.page.waitForFunction(() => {
-    const ov = document.getElementById('urgency-overlay');
-    if (!ov) return false;
-    return parseFloat(getComputedStyle(ov).opacity) > 0;
-  });
-});
 
 When('I wait for {int} ms', async ms => {
   await ctx.page.waitForTimeout(ms);
@@ -67,12 +48,6 @@ Then('the game should not be paused', async () => {
   }
 });
 
-Then('the time remaining should be {int}', async expected => {
-  const val = await ctx.page.evaluate(() => Math.ceil(window.gameScene.timeRemaining));
-  if (val !== expected) {
-    throw new Error(`Expected time remaining ${expected} but got ${val}`);
-  }
-});
 
 When('I record the ship position', async () => {
   await ctx.page.waitForFunction(() => window.gameScene);

--- a/features/step_definitions/world.js
+++ b/features/step_definitions/world.js
@@ -25,8 +25,7 @@ Then('the legend icons should match power-up graphics', async () => {
   );
   const expected = [
     { shape: 'cross', color: '#ffff00' },
-    { shape: 'triangle', color: '#ffa500' },
-    { shape: 'circle', color: '#00ff00' }
+    { shape: 'triangle', color: '#ffa500' }
   ];
   if (
     icons.length !== expected.length ||

--- a/features/urgent_countdown.feature
+++ b/features/urgent_countdown.feature
@@ -1,7 +1,0 @@
-Feature: Urgent countdown display
-  Scenario: Timer turns urgent when less than 10 seconds remain
-    Given I open the game page
-    When I click the start screen
-    And the game should appear after a short delay
-    And I force the timer below ten seconds
-    Then the screen should tint red

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
                 <li>Right click to boost your thrusters</li>
                 <li>Hit red orbs for points and streaks</li>
                 <li>Avoid blue orbs and planets</li>
-                <li>Collect ammo, fuel and time pickups</li>
+                <li>Collect ammo and fuel pickups</li>
             </ul>
             <p>Click anywhere to begin!</p>
         </div>
@@ -41,12 +41,11 @@
         <img src="static/images/space-dock.gif" alt="Space Dock Animation">
     </div>
     <div id="game"></div>
-    <div id="urgency-overlay"></div>
     <div id="fuel-container"><div id="fuel-bar"></div></div>
     <div id="ammo-container">Ammo: <span id="ammo-count">0</span></div>
     <div id="reload-indicator"><div class="fill"></div></div>
     <div id="credits-container">Credits: <span id="credits">0</span></div>
-    <div id="score-container">Score: <span id="score">0</span> | Streak: <span id="streak">0</span> | Time: <span id="time-remaining">60</span></div>
+    <div id="score-container">Score: <span id="score">0</span> | Streak: <span id="streak">0</span></div>
     <div id="level-banner"></div>
     <div id="dock-banner">Docked at Trading Vessel<br><button id="undock-btn">Undock</button></div>
     <div id="shop-overlay">
@@ -67,7 +66,6 @@
     <div id="legend">
         <div><span class="legend-dot ammo" data-shape="cross"></span> Ammo</div>
         <div><span class="legend-dot fuel" data-shape="triangle"></span> Fuel</div>
-        <div><span class="legend-dot time" data-shape="circle"></span> Time</div>
     </div>
     <button id="reset-progress" class="reset-btn" title="Reset all progress">🗑️</button>
     <div id="reset-warning" class="reset-warning">Do you really want to reset?</div>

--- a/static/css/components/overlays.css
+++ b/static/css/components/overlays.css
@@ -14,17 +14,6 @@
     height: 100%;
     object-fit: cover;
 }
-#urgency-overlay {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    pointer-events: none;
-    background-color: red;
-    opacity: 0;
-    transition: opacity 0.2s linear;
-}
 
 #level-banner {
     position: absolute;

--- a/static/css/components/ui.css
+++ b/static/css/components/ui.css
@@ -39,7 +39,6 @@
 
 .legend-dot.ammo { --color: #ffff00; }
 .legend-dot.fuel  { --color: #ffa500; }
-.legend-dot.time  { --color: #00ff00; }
 
 .legend-dot.ammo::before,
 .legend-dot.ammo::after {
@@ -69,24 +68,3 @@
     transform: translate(-50%, -50%);
 }
 
-.legend-dot.time::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 14px;
-    height: 14px;
-    border-radius: 50%;
-    background: var(--color);
-}
-.legend-dot.time::after {
-    content: '';
-    position: absolute;
-    left: 6px;
-    top: 3px;
-    width: 2px;
-    height: 7px;
-    background: #fff;
-    transform-origin: bottom center;
-    transform: rotate(-45deg);
-}

--- a/static/lib/audio.js
+++ b/static/lib/audio.js
@@ -16,8 +16,6 @@
     good: new Audio('static/sounds/hit_good.ogg'),
     bad: new Audio('static/sounds/hit_bad.ogg'),
     pickup: new Audio('static/sounds/pickup.ogg'),
-    tick: new Audio('static/sounds/tick.ogg'),
-    timeout: new Audio('static/sounds/timeout.ogg'),
     crash: new Audio('static/sounds/crash.ogg'),
     explosion: new Audio('static/sounds/explosion.ogg'),
     destroyPickup: new Audio('static/sounds/destroy_pickup.ogg')
@@ -25,14 +23,8 @@
   Object.values(sfx).forEach(a => { a.volume = 0.8; });
   sfx.boost.loop = true;
 
-  function playTick() {
-    sfx.tick.currentTime = 0;
-    sfx.tick.play().catch(() => {});
-  }
-
   window.audioElements = { menuMusic, playTracks, sfx };
   window.sfx = sfx;
-  window.playTick = playTick;
 
   menuMusic.play().catch(() => {});
 })();

--- a/static/lib/game/scene.js
+++ b/static/lib/game/scene.js
@@ -24,16 +24,12 @@
 
     this.shield = stats.shield > 0;
 
-    // Timer and power-ups
-    this.timeRemaining = 60;
+    // Power-ups
     this.powerUps = [];
     this.floatingTexts = [];
     this.nextPowerUpSpawn = 5000;
     this.powerUpSpawnRate = 8000; // milliseconds
     this.powerUpFadeDuration = 9500;
-    this.urgentStarted = false;
-    this.urgentInterval = null;
-    this.urgencyOverlay = document.getElementById('urgency-overlay');
 
     // Orb management
     this.orbs = [];
@@ -161,7 +157,6 @@
     this.streak = 0;
     document.getElementById('score').textContent = this.score;
     document.getElementById('streak').textContent = this.streak;
-    document.getElementById('time-remaining').textContent = Math.ceil(this.timeRemaining);
 
     this.input.mouse.disableContextMenu();
 


### PR DESCRIPTION
## Summary
- strip countdown timer and urgency effects
- update legend, HTML, CSS and audio assets
- drop time powerups and related code
- remove BDD tests referencing the timer

## Testing
- `npm run check`
- `npm test` *(fails: ERR_IPC_CHANNEL_CLOSED)*

------
https://chatgpt.com/codex/tasks/task_e_6855786af968832b810b0206b3281860