### PR TITLE
Remove investment totals from ship stats

### DIFF
--- a/features/inventory_panel.feature
+++ b/features/inventory_panel.feature
@@ -17,3 +17,8 @@ Feature: Inventory panel
     And the inventory stat icon for "Boost Thrust" should be "🚀"
     And the inventory stat icon for "Shield Duration" should be "🛡️"
 
+  Scenario: No investment totals displayed
+    Given I open the game page
+    Then the inventory panel should be visible
+    And the inventory panel should not show investment totals
+

--- a/features/step_definitions/inventory.js
+++ b/features/step_definitions/inventory.js
@@ -67,13 +67,10 @@ Then('the inventory stat {string} should be highlighted', async label => {
   }
 });
 
-Then('the inventory investment for {string} should be {string}', async (label, expected) => {
-  const actual = await ctx.page.evaluate(lbl => {
-    const items = Array.from(document.querySelectorAll('#inventory-panel li'));
-    const el = items.find(i => i.textContent.trim().toLowerCase().startsWith(lbl.toLowerCase()));
-    return el ? el.querySelector('.invest')?.textContent.trim() : null;
-  }, label);
-  if (actual !== expected) {
-    throw new Error(`Expected investment ${expected} but got ${actual}`);
+Then('the inventory panel should not show investment totals', async () => {
+  const count = await ctx.page.$$eval('#inventory-panel .invest', els => els.length);
+  if (count !== 0) {
+    throw new Error('Investment totals should not be visible');
   }
 });
+

--- a/index.html
+++ b/index.html
@@ -28,11 +28,11 @@
         <div id="inventory-panel">
             <h2>Ship Stats</h2>
             <ul>
-                <li class="fuel">Fuel Capacity: <span id="inv-fuel">0</span> (<span class="invest" id="inv-fuel-invested">0</span>)</li>
-                <li class="ammo">Ammo Limit: <span id="inv-ammo">0</span> (<span class="invest" id="inv-ammo-invested">0</span>)</li>
-                <li class="reload">Reload Time: <span id="inv-reload">0</span> (<span class="invest" id="inv-reload-invested">0</span>)</li>
-                <li class="thrust">Boost Thrust: <span id="inv-thrust">0</span> (<span class="invest" id="inv-thrust-invested">0</span>)</li>
-                <li class="shield">Shield Duration: <span id="inv-shield">0</span> (<span class="invest" id="inv-shield-invested">0</span>)</li>
+                <li class="fuel">Fuel Capacity: <span id="inv-fuel">0</span></li>
+                <li class="ammo">Ammo Limit: <span id="inv-ammo">0</span></li>
+                <li class="reload">Reload Time: <span id="inv-reload">0</span></li>
+                <li class="thrust">Boost Thrust: <span id="inv-thrust">0</span></li>
+                <li class="shield">Shield Duration: <span id="inv-shield">0</span></li>
             </ul>
         </div>
     </div>

--- a/static/lib/stats.js
+++ b/static/lib/stats.js
@@ -24,36 +24,12 @@
     return {fuel, ammo, thrust, reload, shield};
   }
 
-  function getCreditInvestments(){
-    const map = {};
-    if(window.shop?.items){
-      for(const it of window.shop.items){
-        map[it.id] = it.cost;
-      }
-    }
-    const active = [...(window.permanentUpgrades || []), ...(window.sessionUpgrades || [])];
-    const invest = { fuel: 0, ammo: 0, reload: 0, thrust: 0, shield: 0 };
-    for(const id of active){
-      if(id === 'extra_fuel') invest.fuel += map[id] || 0;
-      else if(id === 'max_ammo') invest.ammo += map[id] || 0;
-      else if(id === 'boost_thrust') invest.thrust += map[id] || 0;
-      else if(id === 'fast_reload') invest.reload += map[id] || 0;
-      else if(id === 'shield') invest.shield += map[id] || 0;
-    }
-    return invest;
-  }
-
-  function updateInventoryPanel(stats = getCurrentStats(), invest = getCreditInvestments()){
+  function updateInventoryPanel(stats = getCurrentStats()){
     document.getElementById('inv-fuel').textContent = stats.fuel;
-    document.getElementById('inv-fuel-invested').textContent = invest.fuel;
     document.getElementById('inv-ammo').textContent = stats.ammo;
-    document.getElementById('inv-ammo-invested').textContent = invest.ammo;
     document.getElementById('inv-reload').textContent = stats.reload;
-    document.getElementById('inv-reload-invested').textContent = invest.reload;
     document.getElementById('inv-thrust').textContent = stats.thrust;
-    document.getElementById('inv-thrust-invested').textContent = invest.thrust;
     document.getElementById('inv-shield').textContent = stats.shield;
-    document.getElementById('inv-shield-invested').textContent = invest.shield;
   }
 
   function clearPreview(){


### PR DESCRIPTION
## Summary
- simplify start screen ship stats
- remove obsolete investment logic from the stats module
- clean up unused step definition and add a test for absence of investment totals

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68557a8728e8832b89fe4734062f3fd1