### PR TITLE
Attempt to fix BDD failures

### DIFF
--- a/features/step_definitions/hooks.js
+++ b/features/step_definitions/hooks.js
@@ -8,17 +8,29 @@ BeforeAll(async () => {
   ctx.browser = await chromium.launch({
     args: ['--no-sandbox', '--ignore-certificate-errors', '--allow-file-access-from-files']
   });
+  ctx.context = await ctx.browser.newContext();
 });
 
 Before(async () => {
-  ctx.context = await ctx.browser.newContext();
   ctx.page = await ctx.context.newPage();
 });
 
 After(async () => {
-  await ctx.context?.close();
+  try {
+    if (ctx.page) {
+      await ctx.page.close();
+    }
+  } catch {
+    // ignore if already closed
+  }
 });
 
 AfterAll(async () => {
-  await ctx.browser?.close();
+  try {
+    if (ctx.browser) {
+      await ctx.browser.close();
+    }
+  } catch {
+    // ignore if already closed
+  }
 });


### PR DESCRIPTION
## Summary
- reduce flakiness by reusing Playwright context
- close pages after scenarios

## Testing
- `npm run check`
- `npx cucumber-js features/trader_inventory.feature`
- `npx cucumber-js features/shop_overlay.feature`
- `CUCUMBER_PARALLEL=1 npx cucumber-js` *(fails: browser.newContext: Target page, context or browser has been closed)*

------
https://chatgpt.com/codex/tasks/task_e_6855777e649c832bb90e3fda7716099d