### PR TITLE
Add hitbox debug overlay mode

### DIFF
--- a/features/debug_overlay.feature
+++ b/features/debug_overlay.feature
@@ -1,0 +1,5 @@
+Feature: Hitbox debug overlay
+  Scenario: Enabling debug mode shows collision shapes
+    Given I open the game page with debug enabled
+    When I click the start screen
+    Then the debug overlay should be active

--- a/features/step_definitions/gameplay.js
+++ b/features/step_definitions/gameplay.js
@@ -122,3 +122,11 @@ Then('the game should not be over', async () => {
     throw new Error('Game unexpectedly over');
   }
 });
+
+Then('the debug overlay should be active', async () => {
+  await ctx.page.waitForFunction(() => window.gameScene);
+  const active = await ctx.page.evaluate(() => window.debugHitboxes === true);
+  if (!active) {
+    throw new Error('Debug overlay not active');
+  }
+});

--- a/features/step_definitions/navigation.js
+++ b/features/step_definitions/navigation.js
@@ -7,6 +7,11 @@ Given('I open the game page', async () => {
   await ctx.page.goto('file://' + filePath);
 });
 
+Given('I open the game page with debug enabled', async () => {
+  const filePath = path.resolve(__dirname, '../../index.html');
+  await ctx.page.goto('file://' + filePath + '?debug=1');
+});
+
 When('I click the start screen', async () => {
   await ctx.page.click('#start-screen');
 });

--- a/index.html
+++ b/index.html
@@ -86,6 +86,7 @@
         if (!isNaN(ti)) {
             window.traderInterval = ti;
         }
+        window.debugHitboxes = params.get('debug') === '1';
     </script>
     <script src="static/lib/boot.js"></script>
 </body>

--- a/static/lib/game/loop.js
+++ b/static/lib/game/loop.js
@@ -398,6 +398,20 @@
     } else {
         this.reticleCooldown.visible = false;
     }
+
+    if (this.debugGraphics) {
+        this.debugGraphics.clear();
+        if (window.debugHitboxes) {
+            this.debugGraphics.lineStyle(1, 0xff00ff, 0.6);
+            this.debugGraphics.strokeCircle(this.ship.x, this.ship.y, this.shipRadius);
+            for (const p of this.planets) {
+                this.debugGraphics.strokeCircle(p.sprite.x, p.sprite.y, p.radius);
+            }
+            for (const o of this.orbs) {
+                this.debugGraphics.strokeCircle(o.sprite.x, o.sprite.y, o.radius * o.sprite.scaleX);
+            }
+        }
+    }
 }
   window.gameUpdate = update;
 })();

--- a/static/lib/game/scene.js
+++ b/static/lib/game/scene.js
@@ -1,6 +1,11 @@
 (function(){
   function create() {
     window.gameScene = this;
+    this.debugGraphics = this.add.graphics();
+    this.debugGraphics.setDepth(1000);
+    this.input.keyboard.on('keydown-D', () => {
+        window.debugHitboxes = !window.debugHitboxes;
+    });
     // Create a slightly smaller ship using a polygon with an outline
     const shipPoints = [0, -20, 16, 16, 0, 8, -16, 16];
     this.ship = this.add.polygon(400, 300, shipPoints, 0x00ffff);


### PR DESCRIPTION
## Summary
- toggle collision debug overlay with the `debug` URL param or `D` key
- draw collision circles for the ship, orbs and planet in debug mode
- expose debug flag in `index.html`
- add BDD test for enabling the debug overlay

## Testing
- `npm run check`
- `npx cucumber-js features/debug_overlay.feature`

------
https://chatgpt.com/codex/tasks/task_e_68557d656688832b9cdd4f15190e04b1