### PR TITLE
Align ship collision circle

### DIFF
--- a/features/debug_overlay.feature
+++ b/features/debug_overlay.feature
@@ -3,3 +3,9 @@ Feature: Hitbox debug overlay
     Given I open the game page with debug enabled
     When I click the start screen
     Then the debug overlay should be active
+
+  Scenario: Ship hitbox circle uses tuned radius
+    Given I open the game page with debug enabled
+    When I click the start screen
+    Then the debug overlay should be active
+    And the ship hitbox radius should be 12

--- a/features/step_definitions/gameplay.js
+++ b/features/step_definitions/gameplay.js
@@ -130,3 +130,11 @@ Then('the debug overlay should be active', async () => {
     throw new Error('Debug overlay not active');
   }
 });
+
+Then('the ship hitbox radius should be {int}', async r => {
+  await ctx.page.waitForFunction(() => window.gameScene);
+  const val = await ctx.page.evaluate(() => window.gameScene.shipRadius);
+  if (val !== r) {
+    throw new Error(`Expected ship radius ${r} but got ${val}`);
+  }
+});

--- a/static/lib/game/loop.js
+++ b/static/lib/game/loop.js
@@ -24,6 +24,11 @@
     const noseAngle = this.ship.rotation - Math.PI / 2;
     const powerScale = Math.max(0.5, 1 - (this.level - 1) * 0.05);
 
+    const cos = Math.cos(this.ship.rotation);
+    const sin = Math.sin(this.ship.rotation);
+    const shipHitX = this.ship.x + this.shipBodyOffset.x * cos - this.shipBodyOffset.y * sin;
+    const shipHitY = this.ship.y + this.shipBodyOffset.x * sin + this.shipBodyOffset.y * cos;
+
 
     if (this.isFiring && this.ammo > 0 && time > this.lastFired + this.fireRate) {
         const angle = Phaser.Math.Angle.Between(this.ship.x, this.ship.y, this.reticle.x, this.reticle.y);
@@ -201,8 +206,8 @@
         }
         // Check ship collision
         const shipR = this.shipRadius;
-        const dx = this.ship.x - o.sprite.x;
-        const dy = this.ship.y - o.sprite.y;
+        const dx = shipHitX - o.sprite.x;
+        const dy = shipHitY - o.sprite.y;
         if (dx * dx + dy * dy <= (shipR + radius * o.sprite.scaleX) * (shipR + radius * o.sprite.scaleX)) {
             if (this.shield) {
                 this.shield = false;
@@ -242,8 +247,8 @@
             this.powerUps.splice(i, 1);
             continue;
         }
-        const dxP = this.ship.x - p.sprite.x;
-        const dyP = this.ship.y - p.sprite.y;
+        const dxP = shipHitX - p.sprite.x;
+        const dyP = shipHitY - p.sprite.y;
         if (dxP * dxP + dyP * dyP <= 28 * 28) {
             let label;
             if (p.type === 'ammo') {
@@ -332,8 +337,8 @@
     this.ship.y += this.velocity.y * deltaSeconds;
 
     for (let p of this.planets) {
-        const dxp = this.ship.x - p.sprite.x;
-        const dyp = this.ship.y - p.sprite.y;
+        const dxp = shipHitX - p.sprite.x;
+        const dyp = shipHitY - p.sprite.y;
         const shipR = this.shipRadius;
         if (dxp * dxp + dyp * dyp <= (shipR + p.radius) * (shipR + p.radius)) {
             if (this.shield) {
@@ -356,19 +361,19 @@
     const width = this.scale.width;
     const height = this.scale.height;
     const shipR = this.shipRadius;
-    if (this.ship.x - shipR < 0 && this.velocity.x < 0) {
+    if (shipHitX - shipR < 0 && this.velocity.x < 0) {
         this.velocity.x *= -1;
-        this.ship.x = shipR;
-    } else if (this.ship.x + shipR > width && this.velocity.x > 0) {
+        this.ship.x = shipR - this.shipBodyOffset.x;
+    } else if (shipHitX + shipR > width && this.velocity.x > 0) {
         this.velocity.x *= -1;
-        this.ship.x = width - shipR;
+        this.ship.x = width - shipR - this.shipBodyOffset.x;
     }
-    if (this.ship.y - shipR < 0 && this.velocity.y < 0) {
+    if (shipHitY - shipR < 0 && this.velocity.y < 0) {
         this.velocity.y *= -1;
-        this.ship.y = shipR;
-    } else if (this.ship.y + shipR > height && this.velocity.y > 0) {
+        this.ship.y = shipR - this.shipBodyOffset.y;
+    } else if (shipHitY + shipR > height && this.velocity.y > 0) {
         this.velocity.y *= -1;
-        this.ship.y = height - shipR;
+        this.ship.y = height - shipR - this.shipBodyOffset.y;
     }
 
     const fuelPct = Math.max(0, Math.min(100, this.fuel / this.maxFuel * 100));
@@ -403,7 +408,7 @@
         this.debugGraphics.clear();
         if (window.debugHitboxes) {
             this.debugGraphics.lineStyle(1, 0xff00ff, 0.6);
-            this.debugGraphics.strokeCircle(this.ship.x, this.ship.y, this.shipRadius);
+            this.debugGraphics.strokeCircle(shipHitX, shipHitY, this.shipRadius);
             for (const p of this.planets) {
                 this.debugGraphics.strokeCircle(p.sprite.x, p.sprite.y, p.radius);
             }

--- a/static/lib/game/scene.js
+++ b/static/lib/game/scene.js
@@ -11,7 +11,11 @@
     this.ship = this.add.polygon(400, 300, shipPoints, 0x00ffff);
     this.ship.setStrokeStyle(2, 0xffffff);
     this.ship.setOrigin(0.5, 0.5);
-    this.shipRadius = 16;
+    const R = 12;
+    const offsetX = this.ship.width / 2 - R;
+    const offsetY = this.ship.height / 3 - R;
+    this.shipRadius = R;
+    this.shipBodyOffset = new Phaser.Math.Vector2(offsetX, offsetY);
 
     this.velocity = new Phaser.Math.Vector2(0, 0);
     this.isBoosting = false;


### PR DESCRIPTION
## Summary
- tune ship hitbox radius and store offset in the scene setup
- compute circle location from rotation for collisions and debug overlay
- draw and collide using the adjusted circle
- verify radius in a new BDD scenario

## Testing
- `npm run check`
- `npm test` *(fails: Error [ERR_IPC_CHANNEL_CLOSED])*

------
https://chatgpt.com/codex/tasks/task_e_68558181ba3c832ba35fa8a56a8d9e28