### PR TITLE
Calibrate ship hitbox

### DIFF
--- a/features/debug_overlay.feature
+++ b/features/debug_overlay.feature
@@ -8,4 +8,4 @@ Feature: Hitbox debug overlay
     Given I open the game page with debug enabled
     When I click the start screen
     Then the debug overlay should be active
-    And the ship hitbox radius should be 12
+    And the ship hitbox radius should be 16

--- a/static/lib/game/scene.js
+++ b/static/lib/game/scene.js
@@ -11,9 +11,11 @@
     this.ship = this.add.polygon(400, 300, shipPoints, 0x00ffff);
     this.ship.setStrokeStyle(2, 0xffffff);
     this.ship.setOrigin(0.5, 0.5);
-    const R = 12;
-    const offsetX = this.ship.width / 2 - R;
-    const offsetY = this.ship.height / 3 - R;
+    const shipW = this.ship.width;
+    const shipH = this.ship.height;
+    const R = Math.round(shipW / 2);
+    const offsetX = 0;
+    const offsetY = -shipH / 2;
     this.shipRadius = R;
     this.shipBodyOffset = new Phaser.Math.Vector2(offsetX, offsetY);
 


### PR DESCRIPTION
## Summary
- calculate hitbox radius from ship size
- offset the collision circle so it centers on the ship nose
- update debug overlay scenario

## Testing
- `npm run check`
- `npx cucumber-js features/debug_overlay.feature`

------
https://chatgpt.com/codex/tasks/task_e_685585aea504832b871c46dc5f0788ca