### PR TITLE
Center ship collision circle

### DIFF
--- a/features/boundary_bounce.feature
+++ b/features/boundary_bounce.feature
@@ -4,6 +4,6 @@ Feature: Ship boundary bounce
     When I click the start screen
     Then the game should appear after a short delay
     When I place the ship at 10 300 with velocity -200 0
-    And I wait for 150 ms
+    And I wait for 250 ms
     Then the ship x velocity should be positive
     And the ship should be within the screen bounds

--- a/features/debug_overlay.feature
+++ b/features/debug_overlay.feature
@@ -8,4 +8,4 @@ Feature: Hitbox debug overlay
     Given I open the game page with debug enabled
     When I click the start screen
     Then the debug overlay should be active
-    And the ship hitbox radius should be 16
+    And the ship hitbox radius should be 23

--- a/features/powerup_pickup.feature
+++ b/features/powerup_pickup.feature
@@ -4,6 +4,7 @@ Feature: Power-up pickups
     When I click the start screen
     Then the game should appear after a short delay
     When I spawn an ammo power-up on the ship
+    When I wait for 300 ms
     Then the ammo should increase by 15
     And the floating text "+15 Ammo" should appear
 
@@ -13,6 +14,7 @@ Feature: Power-up pickups
     Then the game should appear after a short delay
     When I set the game level to 10
     When I spawn an ammo power-up on the ship
+    When I wait for 300 ms
     Then the ammo should increase by 8
     And the floating text "+8 Ammo" should appear
 

--- a/static/lib/game/scene.js
+++ b/static/lib/game/scene.js
@@ -13,11 +13,18 @@
     this.ship.setOrigin(0.5, 0.5);
     const shipW = this.ship.width;
     const shipH = this.ship.height;
-    const R = Math.round(shipW / 2);
-    const offsetX = 0;
-    const offsetY = -shipH / 2;
+    let maxDistSq = 0;
+    for (let i = 0; i < shipPoints.length; i += 2) {
+        const x = shipPoints[i];
+        const y = shipPoints[i + 1];
+        const d = x * x + y * y;
+        if (d > maxDistSq) {
+            maxDistSq = d;
+        }
+    }
+    const R = Math.ceil(Math.sqrt(maxDistSq));
     this.shipRadius = R;
-    this.shipBodyOffset = new Phaser.Math.Vector2(offsetX, offsetY);
+    this.shipBodyOffset = new Phaser.Math.Vector2(0, 0);
 
     this.velocity = new Phaser.Math.Vector2(0, 0);
     this.isBoosting = false;


### PR DESCRIPTION
## Summary
- compute ship collision radius from polygon and center hitbox
- update hitbox radius BDD test
- tweak boundary bounce timing for bigger hitbox
- wait before ammo pickup assertions

## Testing
- `npm run check`
- `npm test` *(fails: Channel closed)*

------
https://chatgpt.com/codex/tasks/task_e_68559ddc03c4832b99257c4560e4e350