### PR TITLE
Adjust gravity falloff and powerup orbit

### DIFF
--- a/features/powerup_orbit.feature
+++ b/features/powerup_orbit.feature
@@ -8,4 +8,13 @@ Feature: Power-up orbit
     Then a power-up should be visible
     When I record the power-up position
     And I wait for 1200 ms
-    Then the power-up should have moved
+  Then the power-up should have moved
+
+  Scenario: Power-ups orbit at a wider radius
+    Given I open the game page
+    When I click the start screen
+    Then the game should appear after a short delay
+    When I set the next power-up spawn to 0 ms
+    And I wait for 100 ms
+    Then a power-up should be visible
+    Then the power-up orbit radius should be 210

--- a/features/step_definitions/world.js
+++ b/features/step_definitions/world.js
@@ -381,3 +381,23 @@ Then('the power-up should have moved', async () => {
     throw new Error('Power-up did not move');
   }
 });
+
+Then('the power-up orbit radius should be {int}', async expected => {
+  await ctx.page.waitForFunction(() => {
+    return (
+      window.gameScene &&
+      window.gameScene.powerUps.length > 0 &&
+      window.gameScene.planets.length > 0
+    );
+  });
+  const radius = await ctx.page.evaluate(() => {
+    const p = window.gameScene.powerUps[0];
+    const center = window.gameScene.powerUpOrbitCenter || window.gameScene.planets[0].sprite;
+    const dx = p.sprite.x - center.x;
+    const dy = p.sprite.y - center.y;
+    return Math.round(Math.hypot(dx, dy));
+  });
+  if (Math.abs(radius - expected) > 5) {
+    throw new Error(`Expected power-up orbit radius ~${expected} but got ${radius}`);
+  }
+});

--- a/static/lib/game/loop.js
+++ b/static/lib/game/loop.js
@@ -73,7 +73,7 @@
         const dy = p.sprite.y - this.ship.y;
         const distSq = dx * dx + dy * dy;
         if (distSq > 1) {
-            const acc = this.gravityStrength / distSq;
+            const acc = this.gravityStrength / Math.pow(distSq, this.gravityFalloff);
             this.velocity.x += dx * acc * deltaSeconds;
             this.velocity.y += dy * acc * deltaSeconds;
         }
@@ -85,7 +85,7 @@
             const dy = p.sprite.y - o.sprite.y;
             const distSq = dx * dx + dy * dy;
             if (distSq > 1) {
-                const acc = this.gravityStrength / distSq;
+                const acc = this.gravityStrength / Math.pow(distSq, this.gravityFalloff);
                 o.vx += dx * acc * deltaSeconds;
                 o.vy += dy * acc * deltaSeconds;
             }

--- a/static/lib/game/scene.js
+++ b/static/lib/game/scene.js
@@ -68,6 +68,8 @@
     this.planets = [];
     // Reduce gravitational pull slightly for smoother maneuvers
     this.gravityStrength = 2000;
+    // Lower falloff exponent to let gravity influence objects from farther away
+    this.gravityFalloff = 0.9;
     const pr = 120;
     const atmoRadius = pr * 1.5;
     const margin = atmoRadius + 20;
@@ -100,7 +102,8 @@
 
     // Power-up orbit parameters
     this.powerUpOrbitCenter = planet;
-    this.powerUpOrbitRadius = pr + 60;
+    // Slightly widen the power-up orbit for easier interception
+    this.powerUpOrbitRadius = pr + 90;
     this.powerUpAngularSpeed = 0.25; // radians per second
     this.powerUpOrbitDir = Math.random() < 0.5 ? 1 : -1;
 


### PR DESCRIPTION
## Summary
- extend gravity influence range using a falloff exponent
- orbit power-ups further from the planet
- verify orbit radius in BDD tests

## Testing
- `npm run check`
- `npx cucumber-js features/powerup_orbit.feature --name "Power-ups orbit at a wider radius" --parallel 1`
- `CUCUMBER_PARALLEL=2 npm test` *(fails: ERR_IPC_CHANNEL_CLOSED)*

------
https://chatgpt.com/codex/tasks/task_e_6855a027a2ec832ba8498259de1aa884