### PR TITLE
Implement debug hitbox data exposure

### DIFF
--- a/features/debug_overlay.feature
+++ b/features/debug_overlay.feature
@@ -4,6 +4,12 @@ Feature: Hitbox debug overlay
     When I click the start screen
     Then the debug overlay should be active
 
+  Scenario: Debug data exposes ship circle
+    Given I open the game page with debug enabled
+    When I click the start screen
+    Then the debug overlay should be active
+    And the ship debug data should include circle info
+
   Scenario: Ship hitbox circle uses tuned radius
     Given I open the game page with debug enabled
     When I click the start screen

--- a/features/step_definitions/gameplay.js
+++ b/features/step_definitions/gameplay.js
@@ -125,9 +125,17 @@ Then('the game should not be over', async () => {
 
 Then('the debug overlay should be active', async () => {
   await ctx.page.waitForFunction(() => window.gameScene);
-  const active = await ctx.page.evaluate(() => window.debugHitboxes === true);
+  const active = await ctx.page.evaluate(() => window.debugHitboxes?.active === true);
   if (!active) {
     throw new Error('Debug overlay not active');
+  }
+});
+
+Then('the ship debug data should include circle info', async () => {
+  await ctx.page.waitForFunction(() => window.debugHitboxes?.ship);
+  const data = await ctx.page.evaluate(() => window.debugHitboxes.ship);
+  if (!data || typeof data.x !== 'number' || typeof data.y !== 'number' || typeof data.r !== 'number') {
+    throw new Error('Ship debug data missing');
   }
 });
 

--- a/index.html
+++ b/index.html
@@ -86,7 +86,9 @@
         if (!isNaN(ti)) {
             window.traderInterval = ti;
         }
-        window.debugHitboxes = params.get('debug') === '1';
+        window.debugHitboxes = {
+            active: params.get('debug') === '1'
+        };
     </script>
     <script src="static/lib/boot.js"></script>
 </body>

--- a/static/lib/game/loop.js
+++ b/static/lib/game/loop.js
@@ -406,7 +406,8 @@
 
     if (this.debugGraphics) {
         this.debugGraphics.clear();
-        if (window.debugHitboxes) {
+        if (window.debugHitboxes && window.debugHitboxes.active) {
+            window.debugHitboxes.ship = { x: shipHitX, y: shipHitY, r: this.shipRadius };
             this.debugGraphics.lineStyle(1, 0xff00ff, 0.6);
             this.debugGraphics.strokeCircle(shipHitX, shipHitY, this.shipRadius);
             for (const p of this.planets) {

--- a/static/lib/game/scene.js
+++ b/static/lib/game/scene.js
@@ -4,7 +4,11 @@
     this.debugGraphics = this.add.graphics();
     this.debugGraphics.setDepth(1000);
     this.input.keyboard.on('keydown-D', () => {
-        window.debugHitboxes = !window.debugHitboxes;
+        if (!window.debugHitboxes) {
+            window.debugHitboxes = { active: true };
+        } else {
+            window.debugHitboxes.active = !window.debugHitboxes.active;
+        }
     });
     // Create a slightly smaller ship using a polygon with an outline
     const shipPoints = [0, -20, 16, 16, 0, 8, -16, 16];


### PR DESCRIPTION
## Summary
- store debug overlay flag as an object in `index.html`
- toggle debug overlay object inside `scene.js`
- report ship circle data in `loop.js`
- adjust BDD steps for new structure
- test scenario for exposed hitbox data

## Testing
- `npm run check`
- `npm test` *(fails: ERR_IPC_CHANNEL_CLOSED)*

------
https://chatgpt.com/codex/tasks/task_e_6855a25075e0832b830569d235303a36